### PR TITLE
[WinGet][RestSource] Minimal manifest search response schema

### DIFF
--- a/documentation/WinGet-0.2.0.yaml
+++ b/documentation/WinGet-0.2.0.yaml
@@ -1019,7 +1019,6 @@ components:
               $ref: '#/components/schemas/Channel'
       required:
         - PackageVersion
-        - Channel
 
     # Manifest Search Response Schema
     ManifestSearchResponseSchema:
@@ -1050,6 +1049,7 @@ components:
                 $ref: '#/components/schemas/ManifestSearchVersionSchema'
       required:
         - PackageName
+        - Publisher
 
     ResponseObjectSchema:
       description: Base API Response Object


### PR DESCRIPTION
- Adding a minimal manifest search response for the ManifestSearch endpoint, since the client doesn't necessarily need all the manifest information at once.
- Any version specific information can be queried by the client when needed using the Version GET endpoints.