### PR TITLE
Updating package family name and product code to be an array in search response

### DIFF
--- a/documentation/WinGet-0.2.0.yaml
+++ b/documentation/WinGet-0.2.0.yaml
@@ -1223,7 +1223,7 @@ components:
               $ref: '#/components/schemas/Publisher'
         - type: object
           properties:
-            versions:
+            Versions:
               type: array
               items:
                 $ref: '#/components/schemas/ManifestSearchVersionSchema'


### PR DESCRIPTION
- Updated package family name and product code to be an array of string values in search response.
- There will be one PFN/PC per installer.