### PR TITLE
Rest Schema V1.1 changes - Part1

### DIFF
--- a/src/WinGet.RestSource.Functions/PackageManifestFunctions.cs
+++ b/src/WinGet.RestSource.Functions/PackageManifestFunctions.cs
@@ -194,7 +194,8 @@ namespace Microsoft.WinGet.RestSource.Functions
                 // Parse Headers
                 headers = HeaderProcessor.ToDictionary(req.Headers);
 
-                manifests = await this.dataStore.GetPackageManifests(packageIdentifier, req.Query);
+                // Schema supports query parameters only when PackageIdentifier is specified.
+                manifests = await this.dataStore.GetPackageManifests(packageIdentifier, string.IsNullOrWhiteSpace(packageIdentifier) ? null : req.Query);
             }
             catch (DefaultException e)
             {

--- a/src/WinGet.RestSource/Constants/Enumerations/PackageMatchFields.cs
+++ b/src/WinGet.RestSource/Constants/Enumerations/PackageMatchFields.cs
@@ -50,5 +50,10 @@ namespace Microsoft.WinGet.RestSource.Constants.Enumerations
         /// NormalizedPackageNameAndPublisher.
         /// </summary>
         public const string NormalizedPackageNameAndPublisher = "NormalizedPackageNameAndPublisher";
+
+        /// <summary>
+        /// Market.
+        /// </summary>
+        public const string Market = "Market";
     }
 }

--- a/src/WinGet.RestSource/Constants/QueryConstants.cs
+++ b/src/WinGet.RestSource/Constants/QueryConstants.cs
@@ -22,6 +22,11 @@ namespace Microsoft.WinGet.RestSource.Constants
         public const string Channel = "Channel";
 
         /// <summary>
+        /// Query Market.
+        /// </summary>
+        public const string Market = "Market";
+
+        /// <summary>
         /// Query Continuation Token.
         /// </summary>
         public const string ContinuationToken = "ContinuationToken";

--- a/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
+++ b/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
@@ -472,7 +472,7 @@ namespace Microsoft.WinGet.RestSource.Cosmos
             }
 
             // Apply Market Filter. Return only those results that have Market value in installers that match the Market filter.
-            // If Markets is null or markets do not match filter, exclude it from results.
+            // If Markets object is null or markets do not match filter, exclude them from results.
             string marketFilter = queryParameters[QueryConstants.Market];
             this.ApplyMarketFilter(apiDataDocument.Items, marketFilter);
             return apiDataDocument;
@@ -655,12 +655,12 @@ namespace Microsoft.WinGet.RestSource.Cosmos
         {
             if (!string.IsNullOrEmpty(marketFilter))
             {
-                foreach (PackageManifest pm in packageManifests)
+                foreach (PackageManifest packageManifest in packageManifests)
                 {
-                    if (pm.Versions != null)
+                    if (packageManifest.Versions != null)
                     {
                         HashSet<string> versionsWithoutInstallers = new HashSet<string>();
-                        foreach (var version in pm.Versions)
+                        foreach (VersionExtended version in packageManifest.Versions)
                         {
                             if (version.Installers != null)
                             {
@@ -676,7 +676,7 @@ namespace Microsoft.WinGet.RestSource.Cosmos
                                     }
                                 }
 
-                                foreach (string installer in installersNotMatchingFilter)
+                                foreach (var installer in installersNotMatchingFilter)
                                 {
                                     version.RemoveInstaller(installer);
                                 }
@@ -690,7 +690,7 @@ namespace Microsoft.WinGet.RestSource.Cosmos
 
                         foreach (var version in versionsWithoutInstallers)
                         {
-                            pm.RemoveVersion(version);
+                            packageManifest.RemoveVersion(version);
                         }
                     }
                 }

--- a/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
+++ b/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
@@ -471,6 +471,10 @@ namespace Microsoft.WinGet.RestSource.Cosmos
                 }
             }
 
+            // Apply Market Filter. Return only those results that have Market value in installers that match the Market filter.
+            // If Markets is null or markets do not match filter, exclude it from results.
+            string marketFilter = queryParameters[QueryConstants.Market];
+            this.ApplyMarketFilter(apiDataDocument.Items, marketFilter);
             return apiDataDocument;
         }
 
@@ -642,6 +646,57 @@ namespace Microsoft.WinGet.RestSource.Cosmos
             return apiDataPage;
         }
 
+        /// <summary>
+        /// Method to apply market filter and return results.
+        /// </summary>
+        /// <param name="packageManifests">Package manifests on which filter must be applied.</param>
+        /// <param name="marketFilter">Market filter value.</param>
+        internal void ApplyMarketFilter(IList<PackageManifest> packageManifests, string marketFilter)
+        {
+            if (!string.IsNullOrEmpty(marketFilter))
+            {
+                foreach (PackageManifest pm in packageManifests)
+                {
+                    if (pm.Versions != null)
+                    {
+                        HashSet<string> versionsWithoutInstallers = new HashSet<string>();
+                        foreach (var version in pm.Versions)
+                        {
+                            if (version.Installers != null)
+                            {
+                                HashSet<string> installersNotMatchingFilter = new HashSet<string>();
+                                foreach (var installer in version.Installers)
+                                {
+                                    if (installer.Markets == null
+                                        || (installer.Markets.AllowedMarkets == null && installer.Markets.ExcludedMarkets == null)
+                                        || (installer.Markets.AllowedMarkets != null && !installer.Markets.AllowedMarkets.Contains(marketFilter))
+                                        || (installer.Markets.ExcludedMarkets != null && installer.Markets.ExcludedMarkets.Contains(marketFilter)))
+                                    {
+                                        installersNotMatchingFilter.Add(installer.InstallerIdentifier);
+                                    }
+                                }
+
+                                foreach (string installer in installersNotMatchingFilter)
+                                {
+                                    version.RemoveInstaller(installer);
+                                }
+                            }
+
+                            if (version.Installers == null || version.Installers.Count() == 0)
+                            {
+                                versionsWithoutInstallers.Add(version.PackageVersion);
+                            }
+                        }
+
+                        foreach (var version in versionsWithoutInstallers)
+                        {
+                            pm.RemoveVersion(version);
+                        }
+                    }
+                }
+            }
+        }
+
         private bool IsPackageMatchFieldSupported(string packageMatchField)
         {
             bool isPackageMatchFieldSupported = false;
@@ -655,6 +710,7 @@ namespace Microsoft.WinGet.RestSource.Cosmos
                 case PackageMatchFields.Tag:
                 case PackageMatchFields.Command:
                 case PackageMatchFields.Moniker:
+                case PackageMatchFields.Market:
                     isPackageMatchFieldSupported = true;
                     break;
             }
@@ -702,123 +758,143 @@ namespace Microsoft.WinGet.RestSource.Cosmos
                     break;
 
                 case (PackageMatchFields.PackageName, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.Equals(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.Equals(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.PackageName, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.ToLower().Equals(requestMatch.KeyWord.ToLower()));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.ToLower().Equals(requestMatch.KeyWord.ToLower()));
                     break;
 
                 case (PackageMatchFields.PackageName, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.StartsWith(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.StartsWith(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.PackageName, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.Contains(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.PackageName.Contains(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.Moniker, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Moniker.Equals(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.Moniker != null && extended.DefaultLocale.Moniker.Equals(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.Moniker, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Moniker.ToLower().Equals(requestMatch.KeyWord.ToLower()));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.Moniker != null && extended.DefaultLocale.Moniker.ToLower().Equals(requestMatch.KeyWord.ToLower()));
                     break;
 
                 case (PackageMatchFields.Moniker, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Moniker.StartsWith(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.Moniker != null && extended.DefaultLocale.Moniker.StartsWith(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.Moniker, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Moniker.Contains(requestMatch.KeyWord));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.DefaultLocale.Moniker != null && extended.DefaultLocale.Moniker.Contains(requestMatch.KeyWord));
                     break;
 
                 case (PackageMatchFields.Command, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.Commands.Any(command => command.Equals(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Commands != null && installer.Commands.Any(command => command.Equals(requestMatch.KeyWord))));
                     break;
 
                 case (PackageMatchFields.Command, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.Commands.Any(command => command.ToLower().Equals(requestMatch.KeyWord.ToLower()))));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Commands != null && installer.Commands.Any(command => command.ToLower().Equals(requestMatch.KeyWord.ToLower()))));
                     break;
 
                 case (PackageMatchFields.Command, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.Commands.Any(command => command.StartsWith(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Commands != null && installer.Commands.Any(command => command.StartsWith(requestMatch.KeyWord))));
                     break;
 
                 case (PackageMatchFields.Command, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.Commands.Any(command => command.Contains(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Commands != null && installer.Commands.Any(command => command.Contains(requestMatch.KeyWord))));
                     break;
 
                 case (PackageMatchFields.Tag, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Tags.Any(tag => tag.Equals(requestMatch.KeyWord)))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.Tags.Any(tag => tag.Equals(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.Tags != null && extended.DefaultLocale.Tags.Any(tag => tag.Equals(requestMatch.KeyWord)))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.Tags != null && locale.Tags.Any(tag => tag.Equals(requestMatch.KeyWord)))));
                     break;
 
                 case (PackageMatchFields.Tag, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Tags.Any(tag => tag.ToLower().Equals(requestMatch.KeyWord.ToLower())))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.Tags.Any(tag => tag.ToLower().Equals(requestMatch.KeyWord.ToLower()))));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.Tags != null && extended.DefaultLocale.Tags.Any(tag => tag.ToLower().Equals(requestMatch.KeyWord.ToLower())))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.Tags != null && locale.Tags.Any(tag => tag.ToLower().Equals(requestMatch.KeyWord.ToLower())))));
                     break;
 
                 case (PackageMatchFields.Tag, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Tags.Any(tag => tag.StartsWith(requestMatch.KeyWord)))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.Tags.Any(tag => tag.StartsWith(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.Tags != null && extended.DefaultLocale.Tags.Any(tag => tag.StartsWith(requestMatch.KeyWord)))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.Tags != null && locale.Tags.Any(tag => tag.StartsWith(requestMatch.KeyWord)))));
                     break;
 
                 case (PackageMatchFields.Tag, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.Tags.Any(tag => tag.Contains(requestMatch.KeyWord)))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.Tags.Any(tag => tag.Contains(requestMatch.KeyWord))));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.Tags != null && extended.DefaultLocale.Tags.Any(tag => tag.Contains(requestMatch.KeyWord)))
+                       || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.Tags != null && locale.Tags.Any(tag => tag.Contains(requestMatch.KeyWord)))));
                     break;
 
                 case (PackageMatchFields.PackageFamilyName, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.PackageFamilyName.Equals(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.PackageFamilyName != null && installer.PackageFamilyName.Equals(requestMatch.KeyWord)));
                     break;
 
                 case (PackageMatchFields.PackageFamilyName, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.PackageFamilyName.ToLower().Equals(requestMatch.KeyWord.ToLower())));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.PackageFamilyName != null && installer.PackageFamilyName.ToLower().Equals(requestMatch.KeyWord.ToLower())));
                     break;
 
                 case (PackageMatchFields.PackageFamilyName, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.PackageFamilyName.StartsWith(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.PackageFamilyName != null && installer.PackageFamilyName.StartsWith(requestMatch.KeyWord)));
                     break;
 
                 case (PackageMatchFields.PackageFamilyName, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.PackageFamilyName.Contains(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.PackageFamilyName != null && installer.PackageFamilyName.Contains(requestMatch.KeyWord)));
                     break;
 
                 case (PackageMatchFields.ProductCode, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.ProductCode.Equals(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.ProductCode != null && installer.ProductCode.Equals(requestMatch.KeyWord)));
                     break;
 
                 case (PackageMatchFields.ProductCode, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.ProductCode.ToLower().Equals(requestMatch.KeyWord.ToLower())));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.ProductCode != null && installer.ProductCode.ToLower().Equals(requestMatch.KeyWord.ToLower())));
                     break;
 
                 case (PackageMatchFields.ProductCode, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.ProductCode.StartsWith(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.ProductCode != null && installer.ProductCode.StartsWith(requestMatch.KeyWord)));
                     break;
 
                 case (PackageMatchFields.ProductCode, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.Installers.Any(installer => installer.ProductCode.Contains(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.ProductCode != null && installer.ProductCode.Contains(requestMatch.KeyWord)));
                     break;
 
                 case (ShortDescription, MatchType.Exact):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.Equals(requestMatch.KeyWord))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.ShortDescription.Equals(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.Equals(requestMatch.KeyWord))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.ShortDescription != null && locale.ShortDescription.Equals(requestMatch.KeyWord))));
                     break;
 
                 case (ShortDescription, MatchType.CaseInsensitive):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.ToLower().Equals(requestMatch.KeyWord.ToLower()))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.ShortDescription.ToLower().Equals(requestMatch.KeyWord.ToLower())));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.ToLower().Equals(requestMatch.KeyWord.ToLower()))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.ShortDescription != null && locale.ShortDescription.ToLower().Equals(requestMatch.KeyWord.ToLower()))));
                     break;
 
                 case (ShortDescription, MatchType.StartsWith):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.StartsWith(requestMatch.KeyWord))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.ShortDescription.StartsWith(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.StartsWith(requestMatch.KeyWord))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.ShortDescription != null && locale.ShortDescription.StartsWith(requestMatch.KeyWord))));
                     break;
 
                 case (ShortDescription, MatchType.Substring):
-                    expression = manifest => manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.Contains(requestMatch.KeyWord))
-                        || manifest.Versions.Any(extended => extended.Locales.Any(locale => locale.ShortDescription.Contains(requestMatch.KeyWord)));
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.DefaultLocale.ShortDescription.Contains(requestMatch.KeyWord))
+                        || manifest.Versions.Any(extended => extended.Locales != null && extended.Locales.Any(locale => locale.ShortDescription != null && locale.ShortDescription.Contains(requestMatch.KeyWord))));
+                    break;
+
+                case (PackageMatchFields.Market, MatchType.Exact):
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.AllowedMarkets != null && installer.Markets.AllowedMarkets.Any(market => market.Equals(requestMatch.KeyWord))))
+                        || manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.ExcludedMarkets != null && installer.Markets.ExcludedMarkets.Any(market => !market.Equals(requestMatch.KeyWord)))));
+                    break;
+
+                case (PackageMatchFields.Market, MatchType.CaseInsensitive):
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.AllowedMarkets != null && installer.Markets.AllowedMarkets.Any(market => market.ToLower().Equals(requestMatch.KeyWord.ToLower()))))
+                    || manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.ExcludedMarkets != null && installer.Markets.ExcludedMarkets.Any(market => !market.ToLower().Equals(requestMatch.KeyWord.ToLower())))));
+                    break;
+
+                case (PackageMatchFields.Market, MatchType.StartsWith):
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.AllowedMarkets != null && installer.Markets.AllowedMarkets.Any(market => market.StartsWith(requestMatch.KeyWord))))
+                        || manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.ExcludedMarkets != null && installer.Markets.ExcludedMarkets.Any(market => !market.StartsWith(requestMatch.KeyWord)))));
+                    break;
+
+                case (PackageMatchFields.Market, MatchType.Substring):
+                    expression = manifest => manifest.Versions != null && (manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.AllowedMarkets != null && installer.Markets.AllowedMarkets.Any(market => market.Contains(requestMatch.KeyWord))))
+                        || manifest.Versions.Any(extended => extended.Installers != null && extended.Installers.Any(installer => installer.Markets != null && installer.Markets.ExcludedMarkets != null && installer.Markets.ExcludedMarkets.Any(market => !market.Contains(requestMatch.KeyWord)))));
                     break;
 
                 default:

--- a/src/WinGet.RestSource/Models/Arrays/Agreements.cs
+++ b/src/WinGet.RestSource/Models/Arrays/Agreements.cs
@@ -1,0 +1,33 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Agreements.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Arrays
+{
+    using System;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.StringValidators;
+
+    /// <summary>
+    /// Agreements.
+    /// </summary>
+    public class Agreements : ApiArray<Objects.SourceAgreement>
+    {
+        private const bool Nullable = true;
+        private const bool Unique = true;
+        private const uint Max = 16;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Agreements"/> class.
+        /// </summary>
+        public Agreements()
+        {
+            this.APIArrayName = nameof(Agreements);
+            this.AllowNull = Nullable;
+            this.UniqueItems = Unique;
+            this.MaxItems = Max;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Arrays/AppsAndFeaturesEntries.cs
+++ b/src/WinGet.RestSource/Models/Arrays/AppsAndFeaturesEntries.cs
@@ -1,0 +1,32 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AppsAndFeaturesEntries.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Arrays
+{
+    using System;
+    using Microsoft.WinGet.RestSource.Models.Core;
+
+    /// <summary>
+    /// List of ARP entries.
+    /// </summary>
+    public class AppsAndFeaturesEntries : ApiArray<Objects.AppsAndFeatures>
+    {
+        private const bool Nullable = true;
+        private const bool Unique = true;
+        private const uint Max = 128;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppsAndFeaturesEntries"/> class.
+        /// </summary>
+        public AppsAndFeaturesEntries()
+        {
+            this.APIArrayName = nameof(AppsAndFeaturesEntries);
+            this.AllowNull = Nullable;
+            this.UniqueItems = Unique;
+            this.MaxItems = Max;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Arrays/Markets.cs
+++ b/src/WinGet.RestSource/Models/Arrays/Markets.cs
@@ -1,0 +1,35 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Markets.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Arrays
+{
+    using System;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.StringValidators;
+
+    /// <summary>
+    /// Markets.
+    /// </summary>
+    public class Markets : ApiArray<string>
+    {
+        private const bool Nullable = true;
+        private const bool Unique = true;
+        private const int Max = 256;
+        private static readonly Type Validator = typeof(MarketValidator);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Markets"/> class.
+        /// </summary>
+        public Markets()
+        {
+            this.APIArrayName = nameof(Markets);
+            this.AllowNull = Nullable;
+            this.UniqueItems = Unique;
+            this.MaxItems = Max;
+            this.MemberValidator = Validator;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Arrays/UnsupportedOSArchitectures.cs
+++ b/src/WinGet.RestSource/Models/Arrays/UnsupportedOSArchitectures.cs
@@ -1,0 +1,33 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="UnsupportedOSArchitectures.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Arrays
+{
+    using System;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.EnumValidators;
+
+    /// <summary>
+    /// UnsupportedOSArchitectures.
+    /// </summary>
+    public class UnsupportedOSArchitectures : ApiArray<string>
+    {
+        private const bool Nullable = true;
+        private const bool Unique = true;
+        private static readonly Type Validator = typeof(UnsupportedOSArchitecturesValidator);
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UnsupportedOSArchitectures"/> class.
+        /// </summary>
+        public UnsupportedOSArchitectures()
+        {
+            this.APIArrayName = nameof(UnsupportedOSArchitectures);
+            this.AllowNull = Nullable;
+            this.UniqueItems = Unique;
+            this.MemberValidator = Validator;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Objects/AppsAndFeatures.cs
+++ b/src/WinGet.RestSource/Models/Objects/AppsAndFeatures.cs
@@ -1,0 +1,170 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AppsAndFeatures.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Objects
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.WinGet.RestSource.Constants;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.EnumValidators;
+    using Microsoft.WinGet.RestSource.Validators.StringValidators;
+
+    /// <summary>
+    /// AppsAndFeatures.
+    /// </summary>
+    public class AppsAndFeatures : IApiObject<AppsAndFeatures>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppsAndFeatures"/> class.
+        /// </summary>
+        public AppsAndFeatures()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppsAndFeatures"/> class.
+        /// </summary>
+        /// <param name="appsAndFeatures">AppsAndFeatures.</param>
+        public AppsAndFeatures(AppsAndFeatures appsAndFeatures)
+        {
+            this.Update(appsAndFeatures);
+        }
+
+        /// <summary>
+        /// Gets or sets DisplayName.
+        /// </summary>
+        [DisplayAndPublisherNameValidator]
+        public string DisplayName { get; set; }
+
+        /// <summary>
+        /// Gets or sets Publisher.
+        /// </summary>
+        [DisplayAndPublisherNameValidator]
+        public string Publisher { get; set; }
+
+        /// <summary>
+        /// Gets or sets DisplayVersion.
+        /// </summary>
+        [DisplayVersionValidator]
+        public string DisplayVersion { get; set; }
+
+        /// <summary>
+        /// Gets or sets ProductCode.
+        /// </summary>
+        [ProductCodeValidator]
+        public string ProductCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets UpgradeCode.
+        /// </summary>
+        [ProductCodeValidator]
+        public string UpgradeCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets InstallerType.
+        /// </summary>
+        [InstallerTypeValidator]
+        public string InstallerType { get; set; }
+
+        /// <summary>
+        /// Operator==.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator ==(AppsAndFeatures left, AppsAndFeatures right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Operator!=.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator !=(AppsAndFeatures left, AppsAndFeatures right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <inheritdoc />
+        public void Update(AppsAndFeatures obj)
+        {
+            this.DisplayName = obj.DisplayName;
+            this.Publisher = obj.Publisher;
+            this.DisplayVersion = obj.DisplayVersion;
+            this.ProductCode = obj.ProductCode;
+            this.UpgradeCode = obj.UpgradeCode;
+            this.InstallerType = obj.InstallerType;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Return Results
+            return new List<ValidationResult>();
+        }
+
+        /// <inheritdoc />
+        public bool Equals(AppsAndFeatures other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(this.DisplayName, other.DisplayName)
+                && Equals(this.Publisher, other.Publisher)
+                && Equals(this.DisplayVersion, other.DisplayVersion)
+                && Equals(this.ProductCode, other.ProductCode)
+                && Equals(this.UpgradeCode, other.UpgradeCode)
+                && Equals(this.InstallerType, other.InstallerType);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((AppsAndFeatures)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = this.DisplayName != null ? this.DisplayName.GetHashCode() : 0;
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Publisher != null ? this.Publisher.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.DisplayVersion != null ? this.DisplayVersion.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ProductCode != null ? this.ProductCode.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.UpgradeCode != null ? this.UpgradeCode.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.InstallerType != null ? this.InstallerType.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Objects/Markets.cs
+++ b/src/WinGet.RestSource/Models/Objects/Markets.cs
@@ -1,0 +1,152 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Markets.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Objects
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using System.Linq;
+    using Microsoft.WinGet.RestSource.Constants;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators;
+    using Microsoft.WinGet.RestSource.Validators.EnumValidators;
+    using Microsoft.WinGet.RestSource.Validators.StringValidators;
+
+    /// <summary>
+    /// Markets.
+    /// </summary>
+    public class Markets : IApiObject<Markets>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Markets"/> class.
+        /// </summary>
+        public Markets()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Markets"/> class.
+        /// </summary>
+        /// <param name="markets">Markets.</param>
+        public Markets(Markets markets)
+        {
+            this.Update(markets);
+        }
+
+        /// <summary>
+        /// Gets or sets AllowedMarkets.
+        /// </summary>
+        public Arrays.Markets AllowedMarkets { get; set; }
+
+        /// <summary>
+        /// Gets or sets ExcludedMarkets.
+        /// </summary>
+        public Arrays.Markets ExcludedMarkets { get; set; }
+
+        /// <summary>
+        /// Operator==.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator ==(Markets left, Markets right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Operator!=.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator !=(Markets left, Markets right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <inheritdoc />
+        public void Update(Markets obj)
+        {
+            this.AllowedMarkets = obj.AllowedMarkets;
+            this.ExcludedMarkets = obj.ExcludedMarkets;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            // Create Validation Results
+            var results = new List<ValidationResult>();
+
+            if (this.AllowedMarkets != null)
+            {
+                ApiDataValidator.Validate(this.AllowedMarkets, results);
+            }
+
+            if (this.ExcludedMarkets != null)
+            {
+                ApiDataValidator.Validate(this.ExcludedMarkets, results);
+            }
+
+            if (this.AllowedMarkets != null && this.ExcludedMarkets != null)
+            {
+                results.Add(new ValidationResult($"Only one of {nameof(this.AllowedMarkets)} and {nameof(this.ExcludedMarkets)} must be specified."));
+            }
+
+            // Return Results
+            return results;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(Markets other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(this.AllowedMarkets, other.AllowedMarkets)
+                && Equals(this.ExcludedMarkets, other.ExcludedMarkets);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((Markets)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = this.AllowedMarkets != null ? this.AllowedMarkets.GetHashCode() : 0;
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ExcludedMarkets != null ? this.ExcludedMarkets.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Objects/SourceAgreement.cs
+++ b/src/WinGet.RestSource/Models/Objects/SourceAgreement.cs
@@ -1,0 +1,141 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="SourceAgreement.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Objects
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.WinGet.RestSource.Constants;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.StringValidators;
+
+    /// <summary>
+    /// SourceAgreement.
+    /// </summary>
+    public class SourceAgreement : IApiObject<SourceAgreement>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SourceAgreement"/> class.
+        /// </summary>
+        public SourceAgreement()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SourceAgreement"/> class.
+        /// </summary>
+        /// <param name="agreement">Agreement.</param>
+        public SourceAgreement(SourceAgreement agreement)
+        {
+            this.Update(agreement);
+        }
+
+        /// <summary>
+        /// Gets or sets AgreementLabel.
+        /// </summary>
+        [AgreementLabelValidator]
+        public string AgreementLabel { get; set; }
+
+        /// <summary>
+        /// Gets or sets Agreement.
+        /// </summary>
+        [AgreementValidator]
+        public string Agreement { get; set; }
+
+        /// <summary>
+        /// Gets or sets AgreementUrl.
+        /// </summary>
+        [UrlValidator]
+        public string AgreementUrl { get; set; }
+
+        /// <summary>
+        /// Operator==.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator ==(SourceAgreement left, SourceAgreement right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Operator!=.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator !=(SourceAgreement left, SourceAgreement right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <summary>
+        /// This updates the current package core to match another public core.
+        /// </summary>
+        /// <param name="agreement">Package Dependency.</param>
+        public void Update(SourceAgreement agreement)
+        {
+            this.AgreementLabel = agreement.AgreementLabel;
+            this.Agreement = agreement.Agreement;
+            this.AgreementUrl = agreement.AgreementUrl;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            return new List<ValidationResult>();
+        }
+
+        /// <inheritdoc />
+        public bool Equals(SourceAgreement other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(this.AgreementLabel, other.AgreementLabel) && Equals(this.Agreement, other.Agreement) && Equals(this.AgreementUrl, other.AgreementUrl);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((SourceAgreement)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((this.AgreementLabel != null ? this.AgreementLabel.GetHashCode() : 0) * ApiConstants.HashCodeConstant) ^
+                    ((this.Agreement != null ? this.Agreement.GetHashCode() : 0) * ApiConstants.HashCodeConstant) ^
+                    ((this.AgreementUrl != null ? this.AgreementUrl.GetHashCode() : 0) * ApiConstants.HashCodeConstant);
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Schemas/Installer.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Installer.cs
@@ -174,6 +174,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
 
         /// <summary>
         /// Gets or sets a value indicating whether InstallerAbortsTerminal is set.
+        /// This indicates if the package aborts the terminal during installation.
         /// </summary>
         public bool InstallerAbortsTerminal { get; set; }
 

--- a/src/WinGet.RestSource/Models/Schemas/Installer.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Installer.cs
@@ -388,6 +388,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                    && Equals(this.PackageFamilyName, other.PackageFamilyName)
                    && Equals(this.ProductCode, other.ProductCode)
                    && Equals(this.Capabilities, other.Capabilities)
+                   && Equals(this.RestrictedCapabilities, other.RestrictedCapabilities)
                    && Equals(this.MSStoreProductIdentifier, other.MSStoreProductIdentifier)
                    && Equals(this.InstallerAbortsTerminal, other.InstallerAbortsTerminal)
                    && Equals(this.ReleaseDate, other.ReleaseDate)

--- a/src/WinGet.RestSource/Models/Schemas/Installer.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Installer.cs
@@ -189,7 +189,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         public bool InstallLocationRequired { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether the installer should be pinned by default from upgrade.
+        /// Gets or sets a value indicating whether the installer requires explicit upgrade.
         /// </summary>
         public bool RequireExplicitUpgrade { get; set; }
 

--- a/src/WinGet.RestSource/Models/Schemas/Installer.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Installer.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.WinGet.RestSource.Models.Schemas
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
     using Microsoft.WinGet.RestSource.Constants;
@@ -166,6 +167,48 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         public RestrictedCapabilities RestrictedCapabilities { get; set; }
 
         /// <summary>
+        /// Gets or sets MSStoreProductIdentifier.
+        /// </summary>
+        [MSStoreProductIdentifierValidator]
+        public string MSStoreProductIdentifier { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether InstallerAbortsTerminal is set.
+        /// </summary>
+        public bool InstallerAbortsTerminal { get; set; }
+
+        /// <summary>
+        /// Gets or sets ReleaseDate.
+        /// </summary>
+        [ReleaseDateValidator]
+        public DateTime ReleaseDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the installer requires an install location provided.
+        /// </summary>
+        public bool InstallLocationRequired { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the installer should be pinned by default from upgrade.
+        /// </summary>
+        public bool RequireExplicitUpgrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets UnsupportedOSArchitectures.
+        /// </summary>
+        public UnsupportedOSArchitectures UnsupportedOSArchitectures { get; set; }
+
+        /// <summary>
+        /// Gets or sets AppsAndFeaturesEntries.
+        /// </summary>
+        public AppsAndFeaturesEntries AppsAndFeaturesEntries { get; set; }
+
+        /// <summary>
+        /// Gets or sets Markets.
+        /// </summary>
+        public Objects.Markets Markets { get; set; }
+
+        /// <summary>
         /// Operator==.
         /// </summary>
         /// <param name="left">Left.</param>
@@ -212,6 +255,14 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             this.ProductCode = obj.ProductCode;
             this.Capabilities = obj.Capabilities;
             this.RestrictedCapabilities = obj.RestrictedCapabilities;
+            this.MSStoreProductIdentifier = obj.MSStoreProductIdentifier;
+            this.InstallerAbortsTerminal = obj.InstallerAbortsTerminal;
+            this.ReleaseDate = obj.ReleaseDate;
+            this.InstallLocationRequired = obj.InstallLocationRequired;
+            this.RequireExplicitUpgrade = obj.RequireExplicitUpgrade;
+            this.UnsupportedOSArchitectures = obj.UnsupportedOSArchitectures;
+            this.AppsAndFeaturesEntries = obj.AppsAndFeaturesEntries;
+            this.Markets = obj.Markets;
         }
 
         /// <inheritdoc />
@@ -220,10 +271,17 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             // Create Validation Results
             var results = new List<ValidationResult>();
 
-            // URL Are generally nullable, but not in this instance.
-            if (string.IsNullOrEmpty(this.InstallerUrl))
+            // InstallerUrl and InstallerSHA256 should be specified if InstallerType is not msstore.
+            if (this.InstallerType != "msstore" && (string.IsNullOrEmpty(this.InstallerUrl) || string.IsNullOrEmpty(this.InstallerSha256)))
             {
-                results.Add(new ValidationResult($"{nameof(this.InstallerUrl)} in {validationContext.ObjectType} must not be null."));
+                results.Add(new ValidationResult(
+                    $"{nameof(this.InstallerUrl)} and {nameof(this.InstallerSha256)} in {validationContext.ObjectType} must not be null if Installer type is not msstore."));
+            }
+
+            // InstallerUrl and InstallerSHA256 should be specified if InstallerType is not msstore.
+            if (this.InstallerType == "msstore" && string.IsNullOrEmpty(this.MSStoreProductIdentifier))
+            {
+                results.Add(new ValidationResult($"{nameof(this.MSStoreProductIdentifier)} must not be null if Installer type is msstore."));
             }
 
             // Optional Objects
@@ -277,6 +335,21 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                 ApiDataValidator.Validate(this.RestrictedCapabilities, results);
             }
 
+            if (this.UnsupportedOSArchitectures != null)
+            {
+                ApiDataValidator.Validate(this.UnsupportedOSArchitectures, results);
+            }
+
+            if (this.AppsAndFeaturesEntries != null)
+            {
+                ApiDataValidator.Validate(this.AppsAndFeaturesEntries, results);
+            }
+
+            if (this.Markets != null)
+            {
+                ApiDataValidator.Validate(this.Markets, results);
+            }
+
             // Return Results
             return results;
         }
@@ -315,7 +388,14 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                    && Equals(this.PackageFamilyName, other.PackageFamilyName)
                    && Equals(this.ProductCode, other.ProductCode)
                    && Equals(this.Capabilities, other.Capabilities)
-                   && Equals(this.RestrictedCapabilities, other.RestrictedCapabilities);
+                   && Equals(this.MSStoreProductIdentifier, other.MSStoreProductIdentifier)
+                   && Equals(this.InstallerAbortsTerminal, other.InstallerAbortsTerminal)
+                   && Equals(this.ReleaseDate, other.ReleaseDate)
+                   && Equals(this.InstallLocationRequired, other.InstallLocationRequired)
+                   && Equals(this.RequireExplicitUpgrade, other.RequireExplicitUpgrade)
+                   && Equals(this.UnsupportedOSArchitectures, other.UnsupportedOSArchitectures)
+                   && Equals(this.AppsAndFeaturesEntries, other.AppsAndFeaturesEntries)
+                   && Equals(this.Markets, other.Markets);
         }
 
         /// <inheritdoc />
@@ -366,6 +446,14 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ProductCode != null ? this.ProductCode.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Capabilities != null ? this.Capabilities.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.RestrictedCapabilities != null ? this.RestrictedCapabilities.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.MSStoreProductIdentifier != null ? this.MSStoreProductIdentifier.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.InstallerAbortsTerminal.GetHashCode();
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ReleaseDate != null ? this.ReleaseDate.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.InstallLocationRequired.GetHashCode();
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.RequireExplicitUpgrade.GetHashCode();
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.UnsupportedOSArchitectures != null ? this.UnsupportedOSArchitectures.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.AppsAndFeaturesEntries != null ? this.AppsAndFeaturesEntries.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Markets != null ? this.Markets.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/WinGet.RestSource/Models/Schemas/Locale.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Locale.cs
@@ -120,6 +120,23 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         public string Description { get; set; }
 
         /// <summary>
+        /// Gets or sets ReleaseNotes.
+        /// </summary>
+        [ReleaseNotesValidator]
+        public string ReleaseNotes { get; set; }
+
+        /// <summary>
+        /// Gets or sets ReleaseNotesUrl.
+        /// </summary>
+        [UrlValidator]
+        public string ReleaseNotesUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets Agreements.
+        /// </summary>
+        public Agreements Agreements { get; set; }
+
+        /// <summary>
         /// Gets or sets Tags.
         /// </summary>
         public Tags Tags { get; set; }
@@ -164,6 +181,9 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             this.ShortDescription = obj.ShortDescription;
             this.Description = obj.Description;
             this.Tags = obj.Tags;
+            this.ReleaseNotes = obj.ReleaseNotes;
+            this.ReleaseNotesUrl = obj.ReleaseNotesUrl;
+            this.Agreements = obj.Agreements;
         }
 
         /// <inheritdoc />
@@ -175,6 +195,11 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             if (this.Tags != null)
             {
                 ApiDataValidator.Validate(this.Tags, results);
+            }
+
+            if (this.Agreements != null)
+            {
+                ApiDataValidator.Validate(this.Agreements, results);
             }
 
             // Return Results
@@ -208,7 +233,10 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                    && Equals(this.CopyrightUrl, other.CopyrightUrl)
                    && Equals(this.ShortDescription, other.ShortDescription)
                    && Equals(this.Description, other.Description)
-                   && Equals(this.Tags, other.Tags);
+                   && Equals(this.Tags, other.Tags)
+                   && Equals(this.ReleaseNotes, other.ReleaseNotes)
+                   && Equals(this.ReleaseNotesUrl, other.ReleaseNotesUrl)
+                   && Equals(this.Agreements, other.Agreements);
         }
 
         /// <inheritdoc />
@@ -252,6 +280,9 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ShortDescription != null ? this.ShortDescription.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Description != null ? this.Description.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Tags != null ? this.Tags.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ReleaseNotes != null ? this.ReleaseNotes.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ReleaseNotesUrl != null ? this.ReleaseNotesUrl.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Agreements != null ? this.Agreements.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/WinGet.RestSource/Validators/DateTimeValidators/ApiDateTimeValidator.cs
+++ b/src/WinGet.RestSource/Validators/DateTimeValidators/ApiDateTimeValidator.cs
@@ -1,0 +1,93 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ApiDateTimeValidator.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Validators.DateTimeValidators
+{
+    using System;
+    using System.ComponentModel.DataAnnotations;
+
+    /// <summary>
+    /// ApiDateTimeValidator.
+    /// </summary>
+    public class ApiDateTimeValidator : ValidationAttribute
+    {
+        private static string seperator = " ";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiDateTimeValidator"/> class.
+        /// </summary>
+        public ApiDateTimeValidator()
+            : base()
+        {
+            this.SetDefaults();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to Allow Null.
+        /// </summary>
+        protected bool AllowNull { get; set; }
+
+        /// <summary>
+        /// Public Facing Validation.
+        /// </summary>
+        /// <param name="value">Object to validate.</param>
+        /// <param name="validationContext">Validation Context.</param>
+        /// <returns>Validation Result.</returns>
+        public ValidationResult ValidateApiDateTime(object value, ValidationContext validationContext)
+        {
+            return this.IsValid(value, validationContext);
+        }
+
+        /// <summary>
+        /// Verifies if an object is a valid API DateTime based on the parameters.
+        /// </summary>
+        /// <param name="value">Object to validate.</param>
+        /// <param name="validationContext">Validation Context.</param>
+        /// <returns>Validation Result.</returns>
+        protected override ValidationResult IsValid(object value, ValidationContext validationContext)
+        {
+            string errorMessage = null;
+
+            // Check for allowed null
+            if (this.AllowNull && value == null)
+            {
+                return ValidationResult.Success;
+            }
+
+            // Check for disallowed null
+            if (!this.AllowNull && value == null)
+            {
+                errorMessage = this.UpdateErrorMessage(errorMessage, $"{validationContext.DisplayName} in {validationContext.ObjectType} must not be null.");
+                return new ValidationResult(errorMessage);
+            }
+
+            // Check for datetime type and convert
+            if (value.GetType() != typeof(DateTime))
+            {
+                errorMessage = this.UpdateErrorMessage(errorMessage, $"{validationContext.DisplayName} in {validationContext.ObjectType} must be a DateTime type.");
+                return new ValidationResult(errorMessage);
+            }
+
+            // Finalize Validation.
+            if (string.IsNullOrEmpty(errorMessage))
+            {
+                return ValidationResult.Success;
+            }
+
+            return new ValidationResult(errorMessage);
+        }
+
+        private string UpdateErrorMessage(string original, string update)
+        {
+            return string.Join(seperator, original, update);
+        }
+
+        private void SetDefaults()
+        {
+            this.AllowNull = false;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Validators/DateTimeValidators/ReleaseDateValidator.cs
+++ b/src/WinGet.RestSource/Validators/DateTimeValidators/ReleaseDateValidator.cs
@@ -1,26 +1,26 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="ReleaseDateValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
 
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
+    using Microsoft.WinGet.RestSource.Validators.DateTimeValidators;
+
     /// <summary>
-    /// InstallerSha256.
+    /// ReleaseDateValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class ReleaseDateValidator : ApiDateTimeValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="ReleaseDateValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public ReleaseDateValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
         }
     }
 }

--- a/src/WinGet.RestSource/Validators/EnumValidators/PackageMatchFieldValidator.cs
+++ b/src/WinGet.RestSource/Validators/EnumValidators/PackageMatchFieldValidator.cs
@@ -24,6 +24,7 @@ namespace Microsoft.WinGet.RestSource.Validators.EnumValidators
             PackageMatchFields.PackageFamilyName,
             PackageMatchFields.ProductCode,
             PackageMatchFields.NormalizedPackageNameAndPublisher,
+            PackageMatchFields.Market,
         };
 
         /// <summary>

--- a/src/WinGet.RestSource/Validators/EnumValidators/UnsupportedOSArchitecturesValidator.cs
+++ b/src/WinGet.RestSource/Validators/EnumValidators/UnsupportedOSArchitecturesValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerTypeValidator.cs" company="Microsoft Corporation">
+// <copyright file="UnsupportedOSArchitecturesValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -9,30 +9,23 @@ namespace Microsoft.WinGet.RestSource.Validators.EnumValidators
     using System.Collections.Generic;
 
     /// <summary>
-    /// InstallerTypeValidator.
+    /// UnsupportedOSArchitecturesValidator.
     /// </summary>
-    public class InstallerTypeValidator : ApiEnumValidator
+    public class UnsupportedOSArchitecturesValidator : ApiEnumValidator
     {
         private const bool Nullable = true;
         private List<string> enumList = new List<string>
         {
-            "msix",
-            "msi",
-            "appx",
-            "exe",
-            "zip",
-            "inno",
-            "nullsoft",
-            "wix",
-            "burn",
-            "pwa",
-            "msstore",
+            "x86",
+            "x64",
+            "arm",
+            "arm64",
         };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerTypeValidator"/> class.
+        /// Initializes a new instance of the <see cref="UnsupportedOSArchitecturesValidator"/> class.
         /// </summary>
-        public InstallerTypeValidator()
+        public UnsupportedOSArchitecturesValidator()
         {
             this.AllowNull = Nullable;
             this.Values = this.enumList;

--- a/src/WinGet.RestSource/Validators/StringValidators/AgreementLabelValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/AgreementLabelValidator.cs
@@ -1,0 +1,28 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="AgreementLabelValidator.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Validators.StringValidators
+{
+    /// <summary>
+    /// AgreementLabelValidator.
+    /// </summary>
+    public class AgreementLabelValidator : ApiStringValidator
+    {
+        private const bool Nullable = false;
+        private const uint Max = 100;
+        private const uint Min = 1;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgreementLabelValidator"/> class.
+        /// </summary>
+        public AgreementLabelValidator()
+        {
+            this.AllowNull = Nullable;
+            this.MaxLength = Max;
+            this.MinLength = Min;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Validators/StringValidators/AgreementValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/AgreementValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="AgreementValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,20 +7,22 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// AgreementValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class AgreementValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const uint Max = 10000;
+        private const uint Min = 1;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="AgreementValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public AgreementValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
+            this.MaxLength = Max;
+            this.MinLength = Min;
         }
     }
 }

--- a/src/WinGet.RestSource/Validators/StringValidators/DisplayAndPublisherNameValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/DisplayAndPublisherNameValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="DisplayAndPublisherNameValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,20 +7,22 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// DisplayAndPublisherNameValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class DisplayAndPublisherNameValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const uint Min = 1;
+        private const uint Max = 256;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="DisplayAndPublisherNameValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public DisplayAndPublisherNameValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
+            this.MinLength = Min;
+            this.MaxLength = Max;
         }
     }
 }

--- a/src/WinGet.RestSource/Validators/StringValidators/DisplayVersionValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/DisplayVersionValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="DisplayVersionValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,20 +7,22 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// DisplayVersionValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class DisplayVersionValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const uint Min = 1;
+        private const uint Max = 128;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="DisplayVersionValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public DisplayVersionValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
+            this.MinLength = Min;
+            this.MaxLength = Max;
         }
     }
 }

--- a/src/WinGet.RestSource/Validators/StringValidators/MSStoreProductIdentifierValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/MSStoreProductIdentifierValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="MSStoreProductIdentifierValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,17 +7,17 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// MSStoreProductIdentifierValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class MSStoreProductIdentifierValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const string Pattern = "^[A-Za-z0-9]{12}$";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="MSStoreProductIdentifierValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public MSStoreProductIdentifierValidator()
         {
             this.AllowNull = Nullable;
             this.MatchPattern = Pattern;

--- a/src/WinGet.RestSource/Validators/StringValidators/MarketValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/MarketValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="MarketValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,17 +7,17 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// MarketValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class MarketValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const string Pattern = "^[A-Z]{2}$";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="MarketValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public MarketValidator()
         {
             this.AllowNull = Nullable;
             this.MatchPattern = Pattern;

--- a/src/WinGet.RestSource/Validators/StringValidators/ReleaseNotesValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/ReleaseNotesValidator.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSha256Validator.cs" company="Microsoft Corporation">
+// <copyright file="ReleaseNotesValidator.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -7,20 +7,22 @@
 namespace Microsoft.WinGet.RestSource.Validators.StringValidators
 {
     /// <summary>
-    /// InstallerSha256.
+    /// ReleaseNotesValidator.
     /// </summary>
-    public class InstallerSha256Validator : ApiStringValidator
+    public class ReleaseNotesValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^[A-Fa-f0-9]{64}$";
+        private const uint Max = 10000;
+        private const uint Min = 1;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSha256Validator"/> class.
+        /// Initializes a new instance of the <see cref="ReleaseNotesValidator"/> class.
         /// </summary>
-        public InstallerSha256Validator()
+        public ReleaseNotesValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
+            this.MaxLength = Max;
+            this.MinLength = Min;
         }
     }
 }


### PR DESCRIPTION
This PR contains the following changes:

- New Json fields from V1.1 Installer and Locale schema.
- Market query and filter.

Tests:
- Manually validated Installer, locale and package manifests endpoints to ensure database gets the new field values.
- Validated Market query param returns only applicable results in GET package manifest endpoints and search endpoint.

Next PR:
- Will add Information Schema changes in the next PR.