### PR TITLE
Add expected return codes and elevation requirement fields

### DIFF
--- a/documentation/WinGet-1.1.0.yaml
+++ b/documentation/WinGet-1.1.0.yaml
@@ -867,6 +867,14 @@ components:
           minLength: 1
           maxLength: 2048
 
+    InstallerReturnCode:
+      description: An exit code that can be returned by the installer after execution
+      type: integer
+      not:
+        enum: [0]
+      minimum : -2147483648
+      maximum : 429496725
+
     InstallerSuccessCodes:
       description: List of supported installer modes
       type: array
@@ -874,9 +882,48 @@ components:
       uniqueItems: true
       maxItems: 16
       items:
-        type: integer
-        not:
-          enum: [ 0 ]
+        $ref: '#/components/schemas/InstallerReturnCode'
+          
+    ExpectedReturnCodes:
+      description: Installer exit codes for common errors. Should contain unique installer return codes.
+      type: array
+      nullable: true
+      uniqueItems: true
+      maxItems: 128
+      items:
+        $ref: '#/components/schemas/ExpectedReturnCode'
+    
+    ExpectedReturnCodeResponse:
+      description: Installer expected return code response.
+      type: string
+      enum:
+        - packageInUse
+        - installInProgress
+        - fileInUse
+        - missingDependency
+        - diskFull
+        - insufficientMemory
+        - noNetwork
+        - contactSupport
+        - rebootRequiredToFinish
+        - rebootRequiredForInstall
+        - rebootInitiated
+        - cancelledByUser
+        - alreadyInstalled
+        - downgrade
+        - blockedByPolicy
+        
+    ExpectedReturnCode:
+      description: Installer exit code for a common error.
+      type: object
+      properties:
+        InstallerReturnCode:
+          $ref: '#/components/schemas/InstallerReturnCode'
+        ReturnResponse:
+          $ref: '#/components/schemas/ExpectedReturnCodeResponse'
+      required:
+        - InstallerReturnCode
+        - ReturnResponse
 
     UpgradeBehavior:
       description: The upgrade method
@@ -1082,6 +1129,15 @@ components:
       description: Indicates whether the installer should be pinned by default from upgrade.
       type: boolean
 
+    ElevationRequirement:
+      description: The installer's elevation requirement.
+      type: string
+      nullable: true
+      enum:
+        - elevationRequired
+        - elevationProhibited
+        - elevatesSelf
+
     UnsupportedOSArchitectures:
       description: List of OS architectures the installer does not support.
       type: array
@@ -1203,6 +1259,8 @@ components:
           $ref: '#/components/schemas/InstallerSwitches'
         InstallerSuccessCodes:
           $ref: '#/components/schemas/InstallerSuccessCodes'
+        ExpectedReturnCodes:
+          $ref: '#/components/schemas/ExpectedReturnCodes'
         UpgradeBehavior:
           $ref: '#/components/schemas/UpgradeBehavior'
         Commands:
@@ -1231,6 +1289,8 @@ components:
           $ref: '#/components/schemas/InstallLocationRequired'
         RequireExplicitUpgrade:
           $ref: '#/components/schemas/RequireExplicitUpgrade'
+        ElevationRequirement:
+          $ref: '#/components/schemas/ElevationRequirement'
         UnsupportedOSArchitectures:
           $ref: '#/components/schemas/UnsupportedOSArchitectures'
         AppsAndFeaturesEntries:

--- a/src/WinGet.RestSource/Models/Arrays/ExpectedReturnCodes.cs
+++ b/src/WinGet.RestSource/Models/Arrays/ExpectedReturnCodes.cs
@@ -1,5 +1,5 @@
 ﻿// -----------------------------------------------------------------------
-// <copyright file="InstallerSuccessCodes.cs" company="Microsoft Corporation">
+// <copyright file="ExpectedReturnCodes.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
 // -----------------------------------------------------------------------
@@ -11,29 +11,22 @@ namespace Microsoft.WinGet.RestSource.Models.Arrays
     using Microsoft.WinGet.RestSource.Models.Core;
 
     /// <summary>
-    /// InstallerSuccessCodes.
+    /// List of ExpectedReturnCode.
     /// </summary>
-    public class InstallerSuccessCodes : ApiArray<int>
+    public class ExpectedReturnCodes : ApiArray<Objects.ExpectedReturnCode>
     {
-        /// <summary>
-        /// Maximum value of installer return code.
-        /// </summary>
-        public const int MaximumValue = 429496725;
-
         private const bool Nullable = true;
         private const bool Unique = true;
-        private const bool MemberValidation = false;
-        private const uint Max = 16;
+        private const uint Max = 128;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="InstallerSuccessCodes"/> class.
+        /// Initializes a new instance of the <see cref="ExpectedReturnCodes"/> class.
         /// </summary>
-        public InstallerSuccessCodes()
+        public ExpectedReturnCodes()
         {
-            this.APIArrayName = nameof(InstallerSuccessCodes);
+            this.APIArrayName = nameof(ExpectedReturnCodes);
             this.AllowNull = Nullable;
             this.UniqueItems = Unique;
-            this.ValidateMembers = MemberValidation;
             this.MaxItems = Max;
         }
 
@@ -45,18 +38,18 @@ namespace Microsoft.WinGet.RestSource.Models.Arrays
             // Check Base
             results.AddRange(base.Validate(validationContext));
 
-            // Not Zero
-            if (this.Contains(0))
-            {
-                results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer success code of 0."));
-            }
+            Dictionary<int, string> keyValuePairs = new Dictionary<int, string>();
 
-            // Check upper bound
+            // Check for duplicate installer return codes.
             foreach (var code in this)
             {
-                if (code > MaximumValue)
+                if (!keyValuePairs.ContainsKey(code.InstallerReturnCode))
                 {
-                    results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} contains {code} code greater than allowable limit of 429496725."));
+                    keyValuePairs.Add(code.InstallerReturnCode, code.ReturnResponse);
+                }
+                else
+                {
+                    results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} contains duplicate code {code.InstallerReturnCode}."));
                 }
             }
 

--- a/src/WinGet.RestSource/Models/Objects/ExpectedReturnCode.cs
+++ b/src/WinGet.RestSource/Models/Objects/ExpectedReturnCode.cs
@@ -1,0 +1,146 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ExpectedReturnCode.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Models.Objects
+{
+    using System.Collections.Generic;
+    using System.ComponentModel.DataAnnotations;
+    using Microsoft.WinGet.RestSource.Constants;
+    using Microsoft.WinGet.RestSource.Models.Arrays;
+    using Microsoft.WinGet.RestSource.Models.Core;
+    using Microsoft.WinGet.RestSource.Validators.EnumValidators;
+
+    /// <summary>
+    /// ExpectedReturnCode.
+    /// </summary>
+    public class ExpectedReturnCode : IApiObject<ExpectedReturnCode>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpectedReturnCode"/> class.
+        /// </summary>
+        public ExpectedReturnCode()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpectedReturnCode"/> class.
+        /// </summary>
+        /// <param name="expectedReturnCode">Expected return code.</param>
+        public ExpectedReturnCode(ExpectedReturnCode expectedReturnCode)
+        {
+            this.Update(expectedReturnCode);
+        }
+
+        /// <summary>
+        /// Gets or sets InstallerReturnCode.
+        /// </summary>
+        public int InstallerReturnCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets ReturnResponse.
+        /// </summary>
+        [ExpectedReturnCodeResponseValidator]
+        public string ReturnResponse { get; set; }
+
+        /// <summary>
+        /// Operator==.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator ==(ExpectedReturnCode left, ExpectedReturnCode right)
+        {
+            return Equals(left, right);
+        }
+
+        /// <summary>
+        /// Operator!=.
+        /// </summary>
+        /// <param name="left">Left.</param>
+        /// <param name="right">Right.</param>
+        /// <returns>Bool.</returns>
+        public static bool operator !=(ExpectedReturnCode left, ExpectedReturnCode right)
+        {
+            return !Equals(left, right);
+        }
+
+        /// <summary>
+        /// This updates the current expected return code to match another.
+        /// </summary>
+        /// <param name="expectedReturnCode">Expected return code.</param>
+        public void Update(ExpectedReturnCode expectedReturnCode)
+        {
+            this.InstallerReturnCode = expectedReturnCode.InstallerReturnCode;
+            this.ReturnResponse = expectedReturnCode.ReturnResponse;
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            var results = new List<ValidationResult>();
+
+            // Not Zero
+            if (this.InstallerReturnCode == 0)
+            {
+                results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer return code of 0."));
+            }
+
+            // Check upper bound
+            if (this.InstallerReturnCode > InstallerSuccessCodes.MaximumValue)
+            {
+                results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer return code of value greater than 429496725."));
+            }
+
+            return results;
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ExpectedReturnCode other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return Equals(this.InstallerReturnCode, other.InstallerReturnCode) && Equals(this.ReturnResponse, other.ReturnResponse);
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((ExpectedReturnCode)obj);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (this.InstallerReturnCode.GetHashCode() * ApiConstants.HashCodeConstant) ^ (this.ReturnResponse != null ? this.ReturnResponse.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource/Models/Schemas/Installer.cs
+++ b/src/WinGet.RestSource/Models/Schemas/Installer.cs
@@ -14,6 +14,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
     using Microsoft.WinGet.RestSource.Models.Core;
     using Microsoft.WinGet.RestSource.Models.Objects;
     using Microsoft.WinGet.RestSource.Validators;
+    using Microsoft.WinGet.RestSource.Validators.DateTimeValidators;
     using Microsoft.WinGet.RestSource.Validators.EnumValidators;
     using Microsoft.WinGet.RestSource.Validators.StringValidators;
     using Capabilities = Microsoft.WinGet.RestSource.Models.Arrays.Capabilities;
@@ -119,6 +120,11 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         public InstallerSuccessCodes InstallerSuccessCodes { get; set; }
 
         /// <summary>
+        /// Gets or sets ExpectedReturnCodes.
+        /// </summary>
+        public ExpectedReturnCodes ExpectedReturnCodes { get; set; }
+
+        /// <summary>
         /// Gets or sets UpgradeBehavior.
         /// </summary>
         [UpgradeBehaviorValidator]
@@ -195,6 +201,12 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         public bool RequireExplicitUpgrade { get; set; }
 
         /// <summary>
+        /// Gets or sets the installer's elevation requirement.
+        /// </summary>
+        [ElevationRequirementValidator]
+        public string ElevationRequirement { get; set; }
+
+        /// <summary>
         /// Gets or sets UnsupportedOSArchitectures.
         /// </summary>
         public UnsupportedOSArchitectures UnsupportedOSArchitectures { get; set; }
@@ -247,6 +259,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             this.InstallModes = obj.InstallModes;
             this.InstallerSwitches = obj.InstallerSwitches;
             this.InstallerSuccessCodes = obj.InstallerSuccessCodes;
+            this.ExpectedReturnCodes = obj.ExpectedReturnCodes;
             this.UpgradeBehavior = obj.UpgradeBehavior;
             this.Commands = obj.Commands;
             this.Protocols = obj.Protocols;
@@ -261,6 +274,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             this.ReleaseDate = obj.ReleaseDate;
             this.InstallLocationRequired = obj.InstallLocationRequired;
             this.RequireExplicitUpgrade = obj.RequireExplicitUpgrade;
+            this.ElevationRequirement = obj.ElevationRequirement;
             this.UnsupportedOSArchitectures = obj.UnsupportedOSArchitectures;
             this.AppsAndFeaturesEntries = obj.AppsAndFeaturesEntries;
             this.Markets = obj.Markets;
@@ -303,7 +317,12 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
 
             if (this.InstallerSuccessCodes != null)
             {
-                ApiDataValidator.Validate(this.InstallerSwitches, results);
+                ApiDataValidator.Validate(this.InstallerSuccessCodes, results);
+            }
+
+            if (this.ExpectedReturnCodes != null)
+            {
+                ApiDataValidator.Validate(this.ExpectedReturnCodes, results);
             }
 
             if (this.Commands != null)
@@ -381,6 +400,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                    && Equals(this.InstallModes, other.InstallModes)
                    && Equals(this.InstallerSwitches, other.InstallerSwitches)
                    && Equals(this.InstallerSuccessCodes, other.InstallerSuccessCodes)
+                   && Equals(this.ExpectedReturnCodes, other.ExpectedReturnCodes)
                    && Equals(this.UpgradeBehavior, other.UpgradeBehavior)
                    && Equals(this.Commands, other.Commands)
                    && Equals(this.Protocols, other.Protocols)
@@ -395,6 +415,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                    && Equals(this.ReleaseDate, other.ReleaseDate)
                    && Equals(this.InstallLocationRequired, other.InstallLocationRequired)
                    && Equals(this.RequireExplicitUpgrade, other.RequireExplicitUpgrade)
+                   && Equals(this.ElevationRequirement, other.ElevationRequirement)
                    && Equals(this.UnsupportedOSArchitectures, other.UnsupportedOSArchitectures)
                    && Equals(this.AppsAndFeaturesEntries, other.AppsAndFeaturesEntries)
                    && Equals(this.Markets, other.Markets);
@@ -439,6 +460,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.InstallModes != null ? this.InstallModes.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.InstallerSwitches != null ? this.InstallerSwitches.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.InstallerSuccessCodes != null ? this.InstallerSuccessCodes.GetHashCode() : 0);
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ExpectedReturnCodes != null ? this.ExpectedReturnCodes.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.UpgradeBehavior != null ? this.UpgradeBehavior.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Commands != null ? this.Commands.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Protocols != null ? this.Protocols.GetHashCode() : 0);
@@ -453,6 +475,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.ReleaseDate != null ? this.ReleaseDate.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.InstallLocationRequired.GetHashCode();
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.RequireExplicitUpgrade.GetHashCode();
+                hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ this.ElevationRequirement.GetHashCode();
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.UnsupportedOSArchitectures != null ? this.UnsupportedOSArchitectures.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.AppsAndFeaturesEntries != null ? this.AppsAndFeaturesEntries.GetHashCode() : 0);
                 hashCode = (hashCode * ApiConstants.HashCodeConstant) ^ (this.Markets != null ? this.Markets.GetHashCode() : 0);

--- a/src/WinGet.RestSource/Validators/DateTimeValidators/ReleaseDateValidator.cs
+++ b/src/WinGet.RestSource/Validators/DateTimeValidators/ReleaseDateValidator.cs
@@ -4,10 +4,8 @@
 // </copyright>
 // -----------------------------------------------------------------------
 
-namespace Microsoft.WinGet.RestSource.Validators.StringValidators
+namespace Microsoft.WinGet.RestSource.Validators.DateTimeValidators
 {
-    using Microsoft.WinGet.RestSource.Validators.DateTimeValidators;
-
     /// <summary>
     /// ReleaseDateValidator.
     /// </summary>

--- a/src/WinGet.RestSource/Validators/EnumValidators/ElevationRequirementValidator.cs
+++ b/src/WinGet.RestSource/Validators/EnumValidators/ElevationRequirementValidator.cs
@@ -1,0 +1,33 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ElevationRequirementValidator.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Validators.EnumValidators
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// ElevationRequirementValidator.
+    /// </summary>
+    public class ElevationRequirementValidator : ApiEnumValidator
+    {
+        private const bool Nullable = true;
+        private List<string> enumList = new List<string>
+        {
+            "elevationRequired",
+            "elevationProhibited",
+            "elevatesSelf",
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ElevationRequirementValidator"/> class.
+        /// </summary>
+        public ElevationRequirementValidator()
+        {
+            this.AllowNull = Nullable;
+            this.Values = this.enumList;
+        }
+    }
+}

--- a/src/WinGet.RestSource/Validators/EnumValidators/ExpectedReturnCodeResponseValidator.cs
+++ b/src/WinGet.RestSource/Validators/EnumValidators/ExpectedReturnCodeResponseValidator.cs
@@ -1,0 +1,45 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ExpectedReturnCodeResponseValidator.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.Validators.EnumValidators
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Expected Return Code Response.
+    /// </summary>
+    public class ExpectedReturnCodeResponseValidator : ApiEnumValidator
+    {
+        private const bool Nullable = false;
+        private List<string> enumList = new List<string>
+        {
+            "packageInUse",
+            "installInProgress",
+            "fileInUse",
+            "missingDependency",
+            "diskFull",
+            "insufficientMemory",
+            "noNetwork",
+            "contactSupport",
+            "rebootRequiredToFinish",
+            "rebootRequiredForInstall",
+            "rebootInitiated",
+            "cancelledByUser",
+            "alreadyInstalled",
+            "downgrade",
+            "blockedByPolicy",
+        };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExpectedReturnCodeResponseValidator"/> class.
+        /// </summary>
+        public ExpectedReturnCodeResponseValidator()
+        {
+            this.Values = this.enumList;
+            this.AllowNull = Nullable;
+        }
+    }
+}


### PR DESCRIPTION
- This PR contains the Schema changes and ref implementation changes for V1.1 fields that were finalized recently.
- ElevationRequirement and Installer ExpectedReturnCodes

Tests
- Manually tested with Postman and verified all the validation rules are honored for both the fields added. All the Get, put and post methods store and retrieve fields as expected.