### PR TITLE
Update max value of installer return code

### DIFF
--- a/documentation/WinGet-1.1.0.yaml
+++ b/documentation/WinGet-1.1.0.yaml
@@ -873,7 +873,7 @@ components:
       not:
         enum: [0]
       minimum : -2147483648
-      maximum : 429496725
+      maximum : 4294967295
 
     InstallerSuccessCodes:
       description: List of supported installer modes

--- a/src/WinGet.RestSource/Models/Arrays/ExpectedReturnCodes.cs
+++ b/src/WinGet.RestSource/Models/Arrays/ExpectedReturnCodes.cs
@@ -38,7 +38,7 @@ namespace Microsoft.WinGet.RestSource.Models.Arrays
             // Check Base
             results.AddRange(base.Validate(validationContext));
 
-            Dictionary<int, string> keyValuePairs = new Dictionary<int, string>();
+            Dictionary<long, string> keyValuePairs = new Dictionary<long, string>();
 
             // Check for duplicate installer return codes.
             foreach (var code in this)

--- a/src/WinGet.RestSource/Models/Arrays/InstallerSuccessCodes.cs
+++ b/src/WinGet.RestSource/Models/Arrays/InstallerSuccessCodes.cs
@@ -13,12 +13,17 @@ namespace Microsoft.WinGet.RestSource.Models.Arrays
     /// <summary>
     /// InstallerSuccessCodes.
     /// </summary>
-    public class InstallerSuccessCodes : ApiArray<int>
+    public class InstallerSuccessCodes : ApiArray<long>
     {
         /// <summary>
         /// Maximum value of installer return code.
         /// </summary>
-        public const int MaximumValue = 429496725;
+        public const long MaximumValue = 4294967295;
+
+        /// <summary>
+        /// Minimum value of installer return code.
+        /// </summary>
+        public const long MinimumValue = -2147483648;
 
         private const bool Nullable = true;
         private const bool Unique = true;
@@ -51,12 +56,13 @@ namespace Microsoft.WinGet.RestSource.Models.Arrays
                 results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer success code of 0."));
             }
 
-            // Check upper bound
+            // Check bounds
             foreach (var code in this)
             {
-                if (code > MaximumValue)
+                if (code > MaximumValue || code < MinimumValue)
                 {
-                    results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} contains {code} code greater than allowable limit of 429496725."));
+                    results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} contains {code} code " +
+                        $"is out of allowable bounds [{InstallerSuccessCodes.MinimumValue}, {InstallerSuccessCodes.MaximumValue}]."));
                 }
             }
 

--- a/src/WinGet.RestSource/Models/Objects/ExpectedReturnCode.cs
+++ b/src/WinGet.RestSource/Models/Objects/ExpectedReturnCode.cs
@@ -37,7 +37,7 @@ namespace Microsoft.WinGet.RestSource.Models.Objects
         /// <summary>
         /// Gets or sets InstallerReturnCode.
         /// </summary>
-        public int InstallerReturnCode { get; set; }
+        public long InstallerReturnCode { get; set; }
 
         /// <summary>
         /// Gets or sets ReturnResponse.
@@ -88,10 +88,11 @@ namespace Microsoft.WinGet.RestSource.Models.Objects
                 results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer return code of 0."));
             }
 
-            // Check upper bound
-            if (this.InstallerReturnCode > InstallerSuccessCodes.MaximumValue)
+            // Check bounds
+            if (this.InstallerReturnCode > InstallerSuccessCodes.MaximumValue || this.InstallerReturnCode < InstallerSuccessCodes.MinimumValue)
             {
-                results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer return code of value greater than 429496725."));
+                results.Add(new ValidationResult($"{validationContext.DisplayName} in {validationContext.ObjectType} may not contain an installer return" +
+                    $" code that is out of allowable bounds [{InstallerSuccessCodes.MinimumValue}, {InstallerSuccessCodes.MaximumValue}]."));
             }
 
             return results;


### PR DESCRIPTION
- My previous PR contained the installer return code maximum value with a missing number. This PR fixes that.

- Tested minimum and maximum bound is validated for installer return codes.