### PR TITLE
Update implementation to more closely align with wingte yaml rules

### DIFF
--- a/src/WinGet.RestSource/Models/Schemas/ManifestSearchResponse.cs
+++ b/src/WinGet.RestSource/Models/Schemas/ManifestSearchResponse.cs
@@ -9,6 +9,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
+    using System.Linq;
     using Microsoft.WinGet.RestSource.Constants;
     using Microsoft.WinGet.RestSource.Models.Arrays;
     using Microsoft.WinGet.RestSource.Models.Core;
@@ -258,23 +259,17 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
 
             foreach (ManifestSearchResponse response in manifestSearchResponses)
             {
-                // Create Consolidation Predicate for search Response..
-                bool MSRConsolidationExpression(ManifestSearchResponse x) =>
-                    Equals(response.PackageIdentifier, x.PackageIdentifier);
-
                 // If exists in results update otherwise add
-                if (list.Exists(MSRConsolidationExpression))
+                ManifestSearchResponse match = list.FirstOrDefault(x => x.PackageIdentifier == response.PackageIdentifier);
+                if (match != null)
                 {
-                    // Get index
-                    int searchResponseIndex = list.FindIndex(MSRConsolidationExpression);
-
                     // Verify versions exists
-                    if (list[searchResponseIndex].Versions == null && response.Versions != null)
+                    if (match.Versions == null && response.Versions != null)
                     {
-                        list[searchResponseIndex].Versions = new SearchVersions();
+                        match.Versions = new SearchVersions();
                     }
 
-                    list[searchResponseIndex].Versions.Merge(response.Versions);
+                    match.Versions.Merge(response.Versions);
                 }
                 else
                 {

--- a/src/WinGet.RestSource/Models/Schemas/ManifestSearchResponse.cs
+++ b/src/WinGet.RestSource/Models/Schemas/ManifestSearchResponse.cs
@@ -260,9 +260,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             {
                 // Create Consolidation Predicate for search Response..
                 bool MSRConsolidationExpression(ManifestSearchResponse x) =>
-                    Equals(response.PackageIdentifier, x.PackageIdentifier)
-                    && Equals(response.PackageName, x.PackageName)
-                    && Equals(response.Publisher, x.Publisher);
+                    Equals(response.PackageIdentifier, x.PackageIdentifier);
 
                 // If exists in results update otherwise add
                 if (list.Exists(MSRConsolidationExpression))

--- a/src/WinGet.RestSource/Models/Schemas/PackageManifest.cs
+++ b/src/WinGet.RestSource/Models/Schemas/PackageManifest.cs
@@ -109,6 +109,38 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
         }
 
         /// <summary>
+        /// Add Version.
+        /// </summary>
+        /// <param name="version">Version to add.</param>
+        public void AddVersion(VersionExtended version)
+        {
+            // Verify Parameters not null
+            ApiDataValidator.NotNull(version);
+
+            if (this.Versions == null)
+            {
+                this.Versions = new VersionsExtended();
+            }
+
+            this.Versions.Add(version);
+        }
+
+        /// <summary>
+        /// Update a Version.
+        /// </summary>
+        /// <param name="version">Version to Update.</param>
+        public void UpdateVersion(VersionExtended version)
+        {
+            // Verify Parameters not null
+            ApiDataValidator.NotNull(version);
+
+            // Assert Versions not null
+            this.AssertVersionsNotNull();
+
+            this.Versions.Update(version);
+        }
+
+        /// <summary>
         /// Remove a Version.
         /// </summary>
         /// <param name="packageVersion">Version to Remove.</param>

--- a/src/WinGet.RestSource/Models/Schemas/PackageManifest.cs
+++ b/src/WinGet.RestSource/Models/Schemas/PackageManifest.cs
@@ -85,10 +85,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             // Verify Parameters not null
             ApiDataValidator.NotNull(version);
 
-            if (this.Versions == null)
-            {
-                this.Versions = new VersionsExtended();
-            }
+            this.Versions ??= new VersionsExtended();
 
             this.Versions.Add(version);
         }
@@ -117,10 +114,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             // Verify Parameters not null
             ApiDataValidator.NotNull(version);
 
-            if (this.Versions == null)
-            {
-                this.Versions = new VersionsExtended();
-            }
+            this.Versions ??= new VersionsExtended();
 
             this.Versions.Add(version);
         }
@@ -185,10 +179,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             ApiDataValidator.NotNull(packageVersion);
 
             // Instantiate if null
-            if (this.Versions == null)
-            {
-                this.Versions = new VersionsExtended();
-            }
+            this.Versions ??= new VersionsExtended();
 
             this.Versions.AddInstaller(installer, packageVersion);
         }
@@ -256,10 +247,7 @@ namespace Microsoft.WinGet.RestSource.Models.Schemas
             ApiDataValidator.NotNull(packageVersion);
 
             // Instantiate if null
-            if (this.Versions == null)
-            {
-                this.Versions = new VersionsExtended();
-            }
+            this.Versions ??= new VersionsExtended();
 
             this.Versions.AddLocale(locale, packageVersion);
         }

--- a/src/WinGet.RestSource/Validators/StringValidators/LicenseValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/LicenseValidator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         /// </summary>
         public LicenseValidator()
         {
+            this.AllowNull = true;
             this.MinLength = Min;
             this.MaxLength = Max;
         }

--- a/src/WinGet.RestSource/Validators/StringValidators/LocaleValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/LocaleValidator.cs
@@ -12,7 +12,6 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
     public class LocaleValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^([a-zA-Z]{2}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$";
         private const uint Max = 20;
 
         /// <summary>
@@ -21,7 +20,6 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         public LocaleValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
             this.MaxLength = Max;
         }
     }

--- a/src/WinGet.RestSource/Validators/StringValidators/LocaleValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/LocaleValidator.cs
@@ -12,6 +12,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
     public class LocaleValidator : ApiStringValidator
     {
         private const bool Nullable = true;
+        private const string Pattern = "^([a-zA-Z]{2,3}|[iI]-[a-zA-Z]+|[xX]-[a-zA-Z]{1,8})(-[a-zA-Z]{1,8})*$";
         private const uint Max = 20;
 
         /// <summary>
@@ -20,6 +21,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         public LocaleValidator()
         {
             this.AllowNull = Nullable;
+            this.MatchPattern = Pattern;
             this.MaxLength = Max;
         }
     }

--- a/src/WinGet.RestSource/Validators/StringValidators/PackageNameValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/PackageNameValidator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         /// </summary>
         public PackageNameValidator()
         {
+            this.AllowNull = true;
             this.MinLength = Min;
             this.MaxLength = Max;
         }

--- a/src/WinGet.RestSource/Validators/StringValidators/PublisherValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/PublisherValidator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         /// </summary>
         public PublisherValidator()
         {
+            this.AllowNull = true;
             this.MinLength = Min;
             this.MaxLength = Max;
         }

--- a/src/WinGet.RestSource/Validators/StringValidators/ShortDescriptionValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/ShortDescriptionValidator.cs
@@ -19,6 +19,7 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         /// </summary>
         public ShortDescriptionValidator()
         {
+            this.AllowNull = true;
             this.MinLength = Min;
             this.MaxLength = Max;
         }

--- a/src/WinGet.RestSource/Validators/StringValidators/TagValidator.cs
+++ b/src/WinGet.RestSource/Validators/StringValidators/TagValidator.cs
@@ -12,7 +12,6 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
     public class TagValidator : ApiStringValidator
     {
         private const bool Nullable = true;
-        private const string Pattern = "^\\S+$";
         private const uint Min = 1;
         private const uint Max = 40;
 
@@ -22,7 +21,6 @@ namespace Microsoft.WinGet.RestSource.Validators.StringValidators
         public TagValidator()
         {
             this.AllowNull = Nullable;
-            this.MatchPattern = Pattern;
             this.MinLength = Min;
             this.MaxLength = Max;
         }


### PR DESCRIPTION
This change:
1. Revises app groupings on search to reflect that versions from the same package ID may not have the same name/publisher.
2. Updates a variety of validator rules to allow for nulls or looser pattern matches as the yaml schema allows.
3. Updates package manifest to support extended versions.