### PR TITLE
Splitting Cosmos operations into read-only vs. read-write to ensure least-privilege access

### DIFF
--- a/src/WinGet.RestSource.Functions/Startup.cs
+++ b/src/WinGet.RestSource.Functions/Startup.cs
@@ -14,6 +14,7 @@ namespace Microsoft.WinGet.RestSource.Functions
     using System.IO;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Microsoft.WinGet.RestSource.Common;
     using Microsoft.WinGet.RestSource.Constants;
     using Microsoft.WinGet.RestSource.Cosmos;
@@ -26,26 +27,13 @@ namespace Microsoft.WinGet.RestSource.Functions
         /// <inheritdoc />
         public override void Configure(IFunctionsHostBuilder builder)
         {
-            builder.Services.AddSingleton<ICosmosDatabase>((s) => this.CreateCosmosDatabase());
-            builder.Services.AddSingleton<IApiDataStore, CosmosDataStore>();
-        }
+            string endpoint = Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosAccountEndpointSetting) ?? throw new InvalidDataException();
+            string readOnlyKey = Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosReadWriteKeySetting) ?? throw new InvalidDataException();
+            string readWriteKey = Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosReadWriteKeySetting) ?? throw new InvalidDataException();
+            string databaseId = Environment.GetEnvironmentVariable(CosmosConnectionConstants.DatabaseNameSetting) ?? throw new InvalidDataException();
+            string containerId = Environment.GetEnvironmentVariable(CosmosConnectionConstants.ContainerNameSetting) ?? throw new InvalidDataException();
 
-        /// <summary>
-        /// This instantiates a Cosmos DB from the Endpoint and Account Key.
-        /// </summary>
-        /// <returns>Cosmos Database.</returns>
-        private CosmosDatabase CreateCosmosDatabase()
-        {
-            Uri endpoint = new Uri(
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosAccountEndpointSetting) ??
-                throw new InvalidDataException());
-            CosmosDatabase database = new CosmosDatabase(
-                endpoint,
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosAccountKeySetting),
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.DatabaseNameSetting),
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.ContainerNameSetting));
-
-            return database;
+            builder.Services.AddSingleton<IApiDataStore, CosmosDataStore>(sp => new CosmosDataStore(sp.GetRequiredService<ILogger<CosmosDataStore>>(), endpoint, readWriteKey, readOnlyKey, databaseId, containerId));
         }
     }
 }

--- a/src/WinGet.RestSource.Functions/local.settings.template.json
+++ b/src/WinGet.RestSource.Functions/local.settings.template.json
@@ -4,7 +4,8 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet",
     "CosmosAccountEndpoint": "<your CosmosDB endpoint>",
-    "CosmosAccountKey": "<your CosmosDB account key>",
+    "CosmosReadOnlyKey": "<your CosmosDB read-only account key>",
+    "CosmosReadWriteKey": "<your CosmosDB read-write account key>",
     "CosmosDatabase": "<your CosmosDB database>",
     "CosmosContainer": "<your CosmosDB container>",
     "ServerIdentifier": "winget-pkgs-restsource-dev"

--- a/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
+++ b/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
@@ -114,7 +114,8 @@
         "appInsightResourceId": "[resourceId(parameters('appInsightSubscription'), parameters('appInsightResourceGroup'), 'microsoft.insights/components', parameters('appInsightName'))]",
         "kv_secreturi_path": "[concat('https://',parameters('keyVaultName'),'.vault.azure.net/secrets/')]",
         "kv_cosmosAccountEndpoint_secretName": "CosmosAccountEndpoint",
-        "kv_cosmosAccountKey_secretName": "CosmosAccountKey"
+        "kv_cosmosReadWriteKey_secretName": "CosmosReadWriteKey",
+        "kv_cosmosReadOnlyKey_secretName": "CosmosReadOnlyKey"
     },
     "resources": [
         {
@@ -162,7 +163,8 @@
                         "WEBSITE_CONTENTSHARE": "[toLower(parameters('functionName'))]",
                         "WEBSITE_LOAD_CERTIFICATES": "[parameters('website_load_certificates')]",
                         "CosmosAccountEndpoint": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_cosmosAccountEndpoint_secretName'), '/)')]",
-                        "CosmosAccountKey": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_cosmosAccountKey_secretName'), '/)')]"
+                        "CosmosReadWriteKey": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_cosmosReadWriteKey_secretName'), '/)')]",
+                        "CosmosReadOnlyKey": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_cosmosReadOnlyKey_secretName'), '/)')]"
                     }
                 }
             ]

--- a/src/WinGet.RestSource/Constants/CosmosConnectionConstants.cs
+++ b/src/WinGet.RestSource/Constants/CosmosConnectionConstants.cs
@@ -27,9 +27,14 @@ namespace Microsoft.WinGet.RestSource.Constants
         public const string CosmosAccountEndpointSetting = "CosmosAccountEndpoint";
 
         /// <summary>
-        /// This is the Cosmos Account Key setting.
+        /// This is the Cosmos read-write key setting.
         /// </summary>
-        public const string CosmosAccountKeySetting = "CosmosAccountKey";
+        public const string CosmosReadWriteKeySetting = "CosmosReadWriteKey";
+
+        /// <summary>
+        /// This is the Cosmos read-only key setting.
+        /// </summary>
+        public const string CosmosReadOnlyKeySetting = "CosmosReadOnlyKey";
 
         /// <summary>
         /// This is the maximum continuation token from cosmos db in kb.

--- a/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
+++ b/src/WinGet.RestSource/Cosmos/CosmosDataStore.cs
@@ -56,18 +56,14 @@ namespace Microsoft.WinGet.RestSource.Cosmos
         /// Initializes a new instance of the <see cref="CosmosDataStore"/> class.
         /// </summary>
         /// <param name="log">Log.</param>
-        public CosmosDataStore(ILogger<CosmosDataStore> log)
+        /// <param name="serviceEndpoint">Service Endpoint.</param>
+        /// <param name="readWriteKey">Authorization Key with read-write permissions.</param>
+        /// <param name="readOnlyKey">Authorization Key with read-only permissions.</param>
+        /// <param name="databaseId">Database.</param>
+        /// <param name="containerId">Database container.</param>
+        public CosmosDataStore(ILogger<CosmosDataStore> log, string serviceEndpoint, string readWriteKey, string readOnlyKey, string databaseId, string containerId)
         {
-            Uri endpoint = new Uri(
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosAccountEndpointSetting) ??
-                throw new System.IO.InvalidDataException());
-            CosmosDatabase database = new CosmosDatabase(
-                endpoint,
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.CosmosAccountKeySetting),
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.DatabaseNameSetting),
-                Environment.GetEnvironmentVariable(CosmosConnectionConstants.ContainerNameSetting));
-
-            this.cosmosDatabase = database;
+            this.cosmosDatabase = new CosmosDatabase(serviceEndpoint, readWriteKey, readOnlyKey, databaseId, containerId);
             this.log = log;
         }
 


### PR DESCRIPTION
To harden our security, we're modifying the CosmosDB operations to use a read-only client when possible. This reduces the chances of a SQL-injection style attack.