### PR TITLE
Fix CI build after change from master to main.

### DIFF
--- a/pipelines/templates/copy-and-publish-powershell.yml
+++ b/pipelines/templates/copy-and-publish-powershell.yml
@@ -11,14 +11,15 @@ steps:
     Contents: |
      ${{ parameters.source }}\Microsoft.Extensions.Logging.Abstractions.dll
      ${{ parameters.source }}\Microsoft.WinGet.PowershellSupport.dll
-     ${{ parameters.source }}\Microsoft.WinGet.RestSource.Util.dll
+     ${{ parameters.source }}\Microsoft.WinGet.RestSource.Utils.dll
      ${{ parameters.source }}\Newtonsoft.Json.dll
      ${{ parameters.source }}\System.ComponentModel.Annotations.dll
      ${{ parameters.source }}\YamlDotNet.dll
-     ${{ parameters.source }}\runtimes\win-${{TargetPlatform}}\native\WinGetUtil.dll
+     ${{ parameters.source }}\runtimes\win-${{ parameters.TargetPlatform }}\native\WinGetUtil.dll
     TargetFolder:  '$(build.artifactstagingdirectory)\${{ parameters.name }}'
     CleanTargetFolder: true
     OverWrite: true
+    flattenFolders: true
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: WinGet.RestSource-${{ parameters.name }}'

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -39,13 +39,14 @@ steps:
   parameters:
     name: WinGet.Restsource.x86PowershellSupport
     source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\bin\$(BuildConfiguration)\netstandard2.0'
-    BuildPlatform: 'x86'
+    TargetPlatform: 'x86'
 
+# Publish x64 powershell binaries
 - template: copy-and-publish-powershell.yml
   parameters:
     name: WinGet.Restsource.x64PowershellSupport
     source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\bin\$(BuildConfiguration)\netstandard2.0'
-    BuildPlatform: 'x64'
+    TargetPlatform: 'x64'
 
 ## Run Unit Tests
 - template: run-unittests.yml

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -3,13 +3,13 @@
 
 # Branches that trigger a build on commit
 trigger:
-- master
+- main
 
 # PR triggers
 pr:
   branches:
     include:
-    - master
+    - main
   paths:
     include:
     - pipelines/*


### PR DESCRIPTION
Issue: When we changes the main branch of the repo from master to main, we neglected to update the CI build pipeline to trigger on main.

Fix: update the pipeline to run on main and clean up a few pipeline issues that weren't caught while the pipeline wasn't running.