### PR TITLE
Removing NormalizedPackageNameAndPublisher from unsupported fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -362,7 +362,7 @@ src/WinGet.RestSource.Functions/local.settings.json
 test.runsettings.json
 
 # Exclude Documentation XML
-src/*/Microsoft.WinGet.*.Documentation.xml
+Microsoft.WinGet.*.Documentation.xml
 
 # Developer ARM template
 src/WinGet.RestSource.Infrastructure/**/*.dev.*json

--- a/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
+++ b/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
@@ -11,7 +11,7 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>1701;1702;NU1701</NoWarn>
-    <DocumentationFile>$(SolutionDir)WinGet.RestSource.Functions\Microsoft.WinGet.RestSource.Functions.Documentation.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.WinGet.RestSource.Functions.Documentation.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -27,18 +27,18 @@
   <ItemGroup>
     <!-- Component Governance fix. Remove when dependency resolving correctly picks up new version, most likely when updating to dotnet 5.0 -->
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.7" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WinGet.RestSource.PowershellSupport/WinGet.RestSource.PowershellSupport.csproj
+++ b/src/WinGet.RestSource.PowershellSupport/WinGet.RestSource.PowershellSupport.csproj
@@ -13,7 +13,7 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>1701;1702;NU1701</NoWarn>
-    <DocumentationFile>$(SolutionDir)WinGet.RestSource\Microsoft.WinGet.PowershellSupport.Documentation.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.WinGet.PowershellSupport.Documentation.xml</DocumentationFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/WinGet.RestSource.UnitTest/WinGet.RestSource.UnitTest.csproj
+++ b/src/WinGet.RestSource.UnitTest/WinGet.RestSource.UnitTest.csproj
@@ -10,7 +10,7 @@
   <PropertyGroup>
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>1701;1702;NU1701</NoWarn>
-    <DocumentationFile>$(SolutionDir)WinGet.RestSource.UnitTest\Microsoft.Winget.RestSource.UnitTest.Documentation.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.Winget.RestSource.UnitTest.Documentation.xml</DocumentationFile>
     <UserSecretsId>09404207-b3a3-4757-83f3-0a1ec9c39c4a</UserSecretsId>
   </PropertyGroup>
 

--- a/src/WinGet.RestSource.Utils/Constants/ApiConstants.cs
+++ b/src/WinGet.RestSource.Utils/Constants/ApiConstants.cs
@@ -30,12 +30,15 @@ namespace Microsoft.WinGet.RestSource.Utils.Constants
 
         /// <summary>
         /// Unsupported package match fields.
-        /// Note: NormalizedPackageNameAndPublisher field support is currently not implemented.
+        /// TODO: NormalizedPackageNameAndPublisher field support is currently not implemented.
         /// GitHub Issue: https://github.com/microsoft/winget-cli-restsource/issues/59.
         /// </summary>
         public static readonly PackageMatchFields UnsupportedPackageMatchFields = new PackageMatchFields()
         {
-            Enumerations.PackageMatchFields.NormalizedPackageNameAndPublisher,
+            // TODO: Currently the winget client sends this field up despite us reporting it as unsupported, so for compatibility
+            // we don't currently return it as unsupported. Above issue needs to be resolved.
+
+            // Enumerations.PackageMatchFields.NormalizedPackageNameAndPublisher,
         };
 
         /// <summary>

--- a/src/WinGet.RestSource.Utils/WinGet.RestSource.Utils.csproj
+++ b/src/WinGet.RestSource.Utils/WinGet.RestSource.Utils.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>Microsoft.WinGet.RestSource.Utils</AssemblyName>
     <WarningsAsErrors />
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DocumentationFile>$(SolutionDir)documentation\Microsoft.WinGet.RestSource.Utils.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.WinGet.RestSource.Utils.Documentation.xml</DocumentationFile>
 
     <!-- Warning 1701;1702: These two compiler warnings are raised when a reference is bound to a different version
          than specified in the assembly reference version number. -->
@@ -17,14 +17,14 @@
     <LangVersion>8</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
   </PropertyGroup>
@@ -42,7 +42,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.WindowsPackageManager.Utils" Version="0.3.4" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
   </ItemGroup>
 

--- a/src/WinGet.RestSource/WinGet.RestSource.csproj
+++ b/src/WinGet.RestSource/WinGet.RestSource.csproj
@@ -12,7 +12,7 @@
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <NoWarn>1701;1702;NU1701</NoWarn>
-    <DocumentationFile>$(SolutionDir)WinGet.RestSource\Microsoft.WinGet.RestSource.Documentation.xml</DocumentationFile>
+    <DocumentationFile>Microsoft.WinGet.RestSource.Documentation.xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
@@ -30,8 +30,6 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="LinqKit" Version="1.1.26" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.22.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="3.0.10" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removing NormalizedPackageNameAndPublisher from unsupported fields since client doesn't handle it correctly

Also doing a little cleanup in the csproj's, making them consistent and removing unneeded nuget dependencies