### PR TITLE
Rename manifest identifier and output folder

### DIFF
--- a/Tools/PowershellModule/src/Library/Add-WinGetManifest.ps1
+++ b/Tools/PowershellModule/src/Library/Add-WinGetManifest.ps1
@@ -124,7 +124,7 @@ Function Add-WinGetManifest
     {
         foreach ($Manifest in $ApplicationManifest) {
             Write-Verbose -Message "Confirming that the Package ID doesn't already exist in Azure for $($Manifest.PackageIdentifier)."
-            $GetResult = Get-WinGetManifest -FunctionName $AzureFunctionName -SubscriptionName $SubscriptionName -ManifestIdentifier $Manifest.PackageIdentifier
+            $GetResult = Get-WinGetManifest -FunctionName $AzureFunctionName -SubscriptionName $SubscriptionName -PackageIdentifier $Manifest.PackageIdentifier
 
             $ManifestObject = $Manifest
             $TriggerName = "ManifestPost"

--- a/Tools/PowershellModule/src/Library/Get-WinGetManifest.ps1
+++ b/Tools/PowershellModule/src/Library/Get-WinGetManifest.ps1
@@ -33,7 +33,7 @@ Function Get-WinGetManifest
     .PARAMETER FunctionName
     Name of the Azure Function Name that contains the Windows Package Manager REST APIs.
 
-    .PARAMETER ManifestIdentifier
+    .PARAMETER PackageIdentifier
     [Optional] The Windows Package Manager Package Identifier of a specific Package Manifest result.
 
     .PARAMETER SubscriptionName
@@ -50,12 +50,12 @@ Function Get-WinGetManifest
     Returns a Manifest object (*.json) of the specified JSON file.
     
     .EXAMPLE
-    Get-WinGetManifest -FunctionName "contosorestsource" -ManifestIdentifier "Windows.PowerToys"
+    Get-WinGetManifest -FunctionName "contosorestsource" -PackageIdentifier "Windows.PowerToys"
 
     Returns a Manifest object of the specified Package Identifier that is queried against in the REST APIs.
 
     .EXAMPLE
-    Get-WinGetManifest -FunctionName "contosorestsource" -ManifestIdentifier "Windows.PowerToys" -SubscriptionName "Visual Studio Subscription"
+    Get-WinGetManifest -FunctionName "contosorestsource" -PackageIdentifier "Windows.PowerToys" -SubscriptionName "Visual Studio Subscription"
 
     Returns a Manifest object of the specified Package Identifier that is queried against in the REST APIs from the specified Subscription Name.
 
@@ -70,7 +70,7 @@ Function Get-WinGetManifest
         [Parameter(Position=0, Mandatory=$true, ParameterSetName="File")]  [string]$Path,
         [Parameter(Position=1, Mandatory=$false,ParameterSetName="File")]  [WinGetManifest]$JSON,
         [Parameter(Position=0, Mandatory=$true, ParameterSetName="Azure")] [string]$FunctionName,
-        [Parameter(Position=1, Mandatory=$false,ParameterSetName="Azure")] [string]$ManifestIdentifier,
+        [Parameter(Position=1, Mandatory=$false,ParameterSetName="Azure")] [string]$PackageIdentifier,
         [Parameter(Position=2, Mandatory=$false,ParameterSetName="Azure")] [string]$SubscriptionName
     )
     BEGIN
@@ -118,8 +118,8 @@ Function Get-WinGetManifest
                     throw "Failed to confirm resources exist in Azure. Please verify and try again."
                 }
 
-                if($ManifestIdentifier){
-                    $ManifestIdentifier = "/$ManifestIdentifier"
+                if($PackageIdentifier){
+                    $PackageIdentifier = "/$PackageIdentifier"
                 }
         
                 ###############################
@@ -244,7 +244,7 @@ Function Get-WinGetManifest
                 $DefaultHostName = $FunctionApp.DefaultHostName
                 $FunctionKey     = (Invoke-AzResourceAction -ResourceId "$FunctionAppId/functions/$TriggerName" -Action listkeys -Force).default
                 $apiHeader.Add("x-functions-key", $FunctionKey)
-                $AzFunctionURL   = "https://" + $DefaultHostName + "/api/" + "packageManifests" + $ManifestIdentifier
+                $AzFunctionURL   = "https://" + $DefaultHostName + "/api/" + "packageManifests" + $PackageIdentifier
                 
                 ## Publishes the Manifest to the Windows Package Manager REST source
                 Write-Verbose -Message "Invoking the REST API call."

--- a/Tools/PowershellModule/src/Library/Remove-WinGetManifest.ps1
+++ b/Tools/PowershellModule/src/Library/Remove-WinGetManifest.ps1
@@ -19,14 +19,14 @@ Function Remove-WinGetManifest
     .PARAMETER FunctionName
     Name of the Azure Function that hosts the REST source.
 
-    .PARAMETER ManifestIdentifier
+    .PARAMETER PackageIdentifier
     THe Package Id that represents the App Manifest to be removed.
 
     .PARAMETER SubscriptionName
     [Optional] The Subscription name contains the Windows Package Manager REST source
 
     .EXAMPLE
-    Remove-WinGetManifest -FunctionName "contosorestsource" -ManifestIdentifier "Windows.PowerToys"
+    Remove-WinGetManifest -FunctionName "contosorestsource" -PackageIdentifier "Windows.PowerToys"
 
     Connects to Azure, then runs the Azure Function "contosorestsource" REST APIs to remove the specified Manifest file from 
     the Windows Package Manager REST source
@@ -35,7 +35,7 @@ Function Remove-WinGetManifest
     [CmdletBinding(DefaultParameterSetName = 'WinGet')]
     PARAM(
         [Parameter(Position=0, Mandatory=$true, ParameterSetName="Azure")] [string]$FunctionName,
-        [Parameter(Position=2, Mandatory=$true)]  [string]$ManifestIdentifier,
+        [Parameter(Position=2, Mandatory=$true)]  [string]$PackageIdentifier,
         [Parameter(Position=3, Mandatory=$false)] [string]$SubscriptionName   = ""
     )
     BEGIN
@@ -72,8 +72,8 @@ Function Remove-WinGetManifest
                     throw "Failed to confirm resources exist in Azure. Please verify and try again."
                 }
 
-                if($ManifestIdentifier){
-                    $ManifestIdentifier = "$ManifestIdentifier"
+                if($PackageIdentifier){
+                    $PackageIdentifier = "$PackageIdentifier"
                 }
         
                 ###############################
@@ -96,7 +96,7 @@ Function Remove-WinGetManifest
                 $apiHeader.Add("Accept", 'application/json')
                 $apiHeader.Add("x-functions-key", $FunctionKey)
 
-                $AzFunctionURL   = "https://" + $DefaultHostName + "/api/" + "packageManifests/" + $ManifestIdentifier
+                $AzFunctionURL   = "https://" + $DefaultHostName + "/api/" + "packageManifests/" + $PackageIdentifier
             }
         }
     }

--- a/pipelines/templates/copy-and-publish-powershell.yml
+++ b/pipelines/templates/copy-and-publish-powershell.yml
@@ -1,4 +1,4 @@
-# Template helper to copy powershell scripts and all dependencies
+# Template helper to copy PowerShell scripts and all dependencies
 parameters:
  helperLibsPath: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\bin\$(BuildConfiguration)\netstandard2.0'
  templatesPath: '$(build.SourcesDirectory)\src\WinGet.RestSource.Infrastructure\bin\$(BuildConfiguration)'
@@ -8,7 +8,7 @@ steps:
   displayName: 'Copy Files: Powershell module'
   inputs:
     SourceFolder: '$(build.SourcesDirectory)\Tools\PowershellModule\src'
-    TargetFolder: '$(build.artifactstagingdirectory)\Winget.Powershell.Source'
+    TargetFolder: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source'
     CleanTargetFolder: true
     OverWrite: true
 
@@ -24,7 +24,7 @@ steps:
      ${{ parameters.helperLibsPath }}\YamlDotNet.dll
      ${{ parameters.helperLibsPath }}\WinGetUtilInterop.dll
      ${{ parameters.helperLibsPath }}\runtimes\win-x86\native\WinGetUtil.dll
-    TargetFolder: '$(build.artifactstagingdirectory)\Winget.Powershell.Source\Library\HelperLib\x86'
+    TargetFolder: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source\Library\HelperLib\x86'
     OverWrite: true
     flattenFolders: true
 
@@ -40,7 +40,7 @@ steps:
      ${{ parameters.helperLibsPath }}\YamlDotNet.dll
      ${{ parameters.helperLibsPath }}\WinGetUtilInterop.dll
      ${{ parameters.helperLibsPath }}\runtimes\win-x64\native\WinGetUtil.dll
-    TargetFolder: '$(build.artifactstagingdirectory)\Winget.Powershell.Source\Library\HelperLib\x64'
+    TargetFolder: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source\Library\HelperLib\x64'
     OverWrite: true
     flattenFolders: true
 
@@ -58,7 +58,7 @@ steps:
      ${{ parameters.templatesPath }}\**\frontdoor.json
      ${{ parameters.templatesPath }}\**\keyvault.json
      ${{ parameters.templatesPath }}\**\storageaccount.json
-    TargetFolder: '$(build.artifactstagingdirectory)\Winget.Powershell.Source\Library\ARMTemplate'
+    TargetFolder: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source\Library\ARMTemplate'
     OverWrite: true
     flattenFolders: true
 
@@ -66,11 +66,11 @@ steps:
   displayName: 'Copy Files: azure function'
   inputs:
     SourceFolder: '$(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions'
-    TargetFolder: '$(build.artifactstagingdirectory)\Winget.Powershell.Source\Library\RestAPI'
+    TargetFolder: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source\Library\RestAPI'
     OverWrite: true
 
 - task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: WinGet.RestSource-Winget.Powershell.Source'
+  displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
   inputs:
-    PathtoPublish: '$(build.artifactstagingdirectory)\Winget.Powershell.Source'
+    PathtoPublish: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source'
     ArtifactName: 'WinGet.RestSource-Winget.Powershell.Source'

--- a/pipelines/templates/copy-and-publish-powershell.yml
+++ b/pipelines/templates/copy-and-publish-powershell.yml
@@ -73,4 +73,4 @@ steps:
   displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
   inputs:
     PathtoPublish: '$(build.artifactstagingdirectory)\Winget.PowerShell.Source'
-    ArtifactName: 'WinGet.RestSource-Winget.Powershell.Source'
+    ArtifactName: 'WinGet.RestSource-Winget.PowerShell.Source'


### PR DESCRIPTION
This change aligns the cmdlet parameter with the actual package identifier variable name.
It also tweaks the output folders for the build.