### PR TITLE
Changed NuGet configuration to use public repository.

### DIFF
--- a/src/NuGet.config
+++ b/src/NuGet.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="winget" value="https://pkgs.dev.azure.com/ms/winget-cli-restsource/_packaging/winget/nuget/v3/index.json" />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
   <packageRestore>
     <add key="enabled" value="True" />


### PR DESCRIPTION
The NuGet configuration was using a internal Microsoft NuGet source, which meant nobody outside who was trying to use this code could restore successfully. 

The public repo appears to contain all of the necessary packages, so restore is successful.