### PR TITLE
Adding integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Running tests are a great way to ensure that functionality is preserved across m
 * Copy the `WinGet.RestSource.IntegrationTest\Test.runsettings.template.json` template configuration to `Test.runsettings.json`
   * Modify the `RestSourceUrl` property to point to a deployed rest source endpoint. You can use the below instructions to deploy a rest instance.
   * If the local winget client doesn't already have the source added, the integration tests can add it. To do so, change the `AddRestSource` property to true. Visual Studio must be running as admin in this case.
-  * There is a test case that **modifies** the rest source. By default it's disabled, to run it the `RunWriteTests` setting must be set to true. The `FunctionsMasterKey` setting must also be set since the add/update/delete endpoints all require function authorization.
+  * There is a test case that **modifies** the rest source. By default it's disabled, to run it the `RunWriteTests` setting must be set to true. The `FunctionsHostKey` setting must also be set since the add/update/delete endpoints all require function authorization. We recommend creating a new pipeline-specific host key for this purpose.
 
 ## Automatically create a rest source
 

--- a/README.md
+++ b/README.md
@@ -29,18 +29,24 @@ The REST functions can be run locally, but to use winget with them, the function
 
 Your commands to winget will now use your locally running REST instance as the primary source.
 
-## Running Unit Tests
+## Running Tests
 
-Running unit tests are a great way to ensure that functionality is preserved across major changes. You can run these tests in Visual Studio Test Explorer.
+Running tests are a great way to ensure that functionality is preserved across major changes. You can run these tests in Visual Studio Test Explorer. In Visual Studio, run the tests from the menu with Test > Run All Tests
 
-### Testing Prerequisites
+### Unit Testing Prerequisites
 
 * Install the [Cosmos DB Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21)
 * Copy the `WinGet.RestSource.UnitTest\Test.runsettings.template.json` template configuration to `Test.runsettings.json`
   * The defaults should work for your local Cosmos DB emulator instance. You can change the configuration to point to a Cosmos DB instance in Azure instead.
   * Alternatively, all of the test configuration properties can be set as environment variables. This is useful for overriding properties in an ADO build.
 
-In Visual Studio, run the tests from the menu with Test > Run All Tests
+### Integration Testing Prerequisites
+
+* Install the [winget client](https://github.com/microsoft/winget-cli) locally.
+* Copy the `WinGet.RestSource.IntegrationTest\Test.runsettings.template.json` template configuration to `Test.runsettings.json`
+  * Modify the `RestSourceUrl` property to point to a deployed rest source endpoint. You can use the below instructions to deploy a rest instance.
+  * If the local winget client doesn't already have the source added, the integration tests can add it. To do so, change the `AddRestSource` property to true. Visual Studio must be running as admin in this case.
+  * There is a test case that **modifies** the rest source. By default it's disabled, to run it the `RunWriteTests` setting must be set to true. The `FunctionsMasterKey` setting must also be set since the add/update/delete endpoints all require function authorization.
 
 ## Automatically create a rest source
 

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -46,14 +46,14 @@ steps:
 - template: run-unittests.yml
   parameters:
     name: WinGet.RestSource.UnitTest
-    source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\netcoreapp3.1'
+    testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\netcoreapp3.1'
     dll: Microsoft.WinGet.RestSource.UnitTest.dll
 
 ## Run Integration Tests
 - template: run-integrationtests.yml
   parameters:
     name: WinGet.RestSource.IntegrationTest
-    source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\bin\$(BuildConfiguration)\netcoreapp5.0'
+    testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\bin\$(BuildConfiguration)\netcoreapp5.0'
     dll: Microsoft.WinGet.RestSource.IntegrationTest.dll
 
 ## Component Governance

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -13,7 +13,7 @@ steps:
     command: 'restore'
     projects: '**/*.csproj'
     feedsToUse: 'config'
-    nugetConfigPath: '$(Build.SourcesDirectory)\src\NuGEt.config'
+    nugetConfigPath: '$(Build.SourcesDirectory)\src\NuGet.config'
     restoreDirectory: '$(Build.SourcesDirectory)\src\packages'
 
 ## Build
@@ -42,12 +42,19 @@ steps:
 # Publish powershell
 - template: copy-and-publish-powershell.yml
 
-## Run Unit Tests
+# Run Unit Tests
 - template: run-unittests.yml
   parameters:
     name: WinGet.RestSource.UnitTest
     source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\netcoreapp3.1'
     dll: Microsoft.WinGet.RestSource.UnitTest.dll
+
+## Run Integration Tests
+- template: run-integrationtests.yml
+  parameters:
+    name: WinGet.RestSource.IntegrationTest
+    source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\bin\$(BuildConfiguration)\netcoreapp5.0'
+    dll: Microsoft.WinGet.RestSource.IntegrationTest.dll
 
 ## Component Governance
 - task: ComponentGovernanceComponentDetection@0

--- a/pipelines/templates/run-integrationtests.yml
+++ b/pipelines/templates/run-integrationtests.yml
@@ -1,0 +1,45 @@
+# Template helper to copy files and publish them as an artifact
+# If we end up with multiple test dlls, copy the dlls to a test directory
+# and update how the dlls are specified.
+parameters:
+  name: ''
+  dll: ''
+  source: ''
+
+steps:
+- task: DownloadGitHubRelease@0
+  inputs:
+    connection: Microsoft
+    userRepository: microsoft\winget-cli
+    defaultVersionType: 'latest'
+    itemPattern: "+(Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle|*.xml)"
+    downloadPath: '$(System.ArtifactsDirectory)'
+  displayName: Download latest Winget release
+
+- powershell: |
+    # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
+    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\Test.runsettings.template.json" "${{ parameters.source }}\Test.runsettings.json"
+
+    # Get path to license file downloaded from GitHub
+    $licensePath = @(dir "$(System.ArtifactsDirectory)\*License*.xml")[0].FullName
+    $licensePath
+
+    # Install Winget
+    $ProgressPreference = 'SilentlyContinue'
+    iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
+    # iwr https://github.com/microsoft/winget-cli/releases/download/v1.1.12653/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+    Add-AppxProvisionedPackage -Online -PackagePath "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle" -DependencyPackagePath .\Microsoft.VCLibs.x64.14.00.Desktop.appx -LicensePath $licensePath
+    Add-AppxPackage "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
+    winget source add -n "winget-pkgs-restsource" -a $(RestSourceUrl) -t "Microsoft.Rest"
+  displayName: "Setup test pre-requisites"
+
+- task: DotNetCoreCLI@2
+  displayName: 'Run tests: ${{ parameters.name }}'
+  inputs:
+    command: 'test'
+    arguments: "--no-build -c Release"
+    publishTestResults: true
+    projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\*.csproj'
+  env:
+    RestSourceUrl: "$(RestSourceUrl)" #  variable set in pipeline settings
+    

--- a/pipelines/templates/run-integrationtests.yml
+++ b/pipelines/templates/run-integrationtests.yml
@@ -1,10 +1,10 @@
-# Template helper to copy files and publish them as an artifact
+# Template helper to run unit tests
 # If we end up with multiple test dlls, copy the dlls to a test directory
 # and update how the dlls are specified.
 parameters:
   name: ''
   dll: ''
-  source: ''
+  testDirectory: ''
 
 steps:
 - task: DownloadGitHubRelease@0
@@ -18,7 +18,7 @@ steps:
 
 - powershell: |
     # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
-    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\Test.runsettings.template.json" "${{ parameters.source }}\Test.runsettings.json"
+    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
 
     # Get path to license file downloaded from GitHub
     $licensePath = @(dir "$(System.ArtifactsDirectory)\*License*.xml")[0].FullName
@@ -27,10 +27,10 @@ steps:
     # Install Winget
     $ProgressPreference = 'SilentlyContinue'
     iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
-    # iwr https://github.com/microsoft/winget-cli/releases/download/v1.1.12653/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+    iwr https://github.com/microsoft/winget-cli/releases/download/v1.1.12653/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
     Add-AppxProvisionedPackage -Online -PackagePath "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle" -DependencyPackagePath .\Microsoft.VCLibs.x64.14.00.Desktop.appx -LicensePath $licensePath
     Add-AppxPackage "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
-    winget source add -n "winget-pkgs-restsource" -a $(RestSourceUrl) -t "Microsoft.Rest"
+    winget source add -n "winget-cli-restsource" -a $(RestSourceUrl) -t "Microsoft.Rest"
   displayName: "Setup test pre-requisites"
 
 - task: DotNetCoreCLI@2

--- a/pipelines/templates/run-integrationtests.yml
+++ b/pipelines/templates/run-integrationtests.yml
@@ -1,4 +1,4 @@
-# Template helper to run unit tests
+# Template helper to run integration tests
 # If we end up with multiple test dlls, copy the dlls to a test directory
 # and update how the dlls are specified.
 parameters:
@@ -27,7 +27,6 @@ steps:
     # Install Winget
     $ProgressPreference = 'SilentlyContinue'
     iwr https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx -OutFile Microsoft.VCLibs.x64.14.00.Desktop.appx
-    iwr https://github.com/microsoft/winget-cli/releases/download/v1.1.12653/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
     Add-AppxProvisionedPackage -Online -PackagePath "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle" -DependencyPackagePath .\Microsoft.VCLibs.x64.14.00.Desktop.appx -LicensePath $licensePath
     Add-AppxPackage "$(System.ArtifactsDirectory)\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle"
     winget source add -n "winget-cli-restsource" -a $(RestSourceUrl) -t "Microsoft.Rest"

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -16,30 +16,10 @@ steps:
     Start-CosmosDbEmulator
   displayName: "Setup test pre-requisites"
 
-- task: CopyFiles@2
-  displayName: 'Copy Files: ${{ parameters.name }}'
-  inputs:
-    SourceFolder: ${{ parameters.source }}
-    TargetFolder:  '$(build.artifactstagingdirectory)\${{ parameters.name }}'
-    CleanTargetFolder: true
-    OverWrite: true
-  condition: succeeded()
-
-- task: VSTest@2
+- task: DotNetCoreCLI@2
   displayName: 'Run tests: ${{ parameters.name }}'
   inputs:
-    testSelector: 'testAssemblies'
-    testAssemblyVer2: ${{ parameters.dll }}
-    searchFolder: '$(build.artifactstagingdirectory)\${{ parameters.name }}'
-    codeCoverageEnabled: true
-    platform: '$(BuildPlatform)'
-    configuration: '$(BuildConfiguration)'
-    overrideTestrunParameters: '-CosmosAccountEndpoint "$(CosmosDbEmulator.Endpoint)"'
-  condition: succeeded()
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: WinGet.RestSource-${{ parameters.name }}'
-  condition: succeededOrFailed()
-  inputs:
-    PathtoPublish: '$(Agent.TempDirectory)\TestResults'
-    ArtifactName: 'WinGet.RestSource-${{ parameters.name }}'
+    command: 'test'
+    arguments: "--no-build -c Release"
+    publishTestResults: true
+    projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\*.csproj'

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -1,4 +1,4 @@
-# Template helper to run integration tests
+# Template helper to run unit tests
 # If we end up with multiple test dlls, copy the dlls to a test directory
 # and update how the dlls are specified.
 parameters:

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -1,15 +1,15 @@
-# Template helper to copy files and publish them as an artifact
+# Template helper to run integration tests
 # If we end up with multiple test dlls, copy the dlls to a test directory
 # and update how the dlls are specified.
 parameters:
   name: ''
   dll: ''
-  source: ''
+  testDirectory: ''
 
 steps:
 - powershell: |
     # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
-    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.source }}\Test.runsettings.json"
+    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
 
     # Launch Cosmos DB emulator
     Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -20,7 +20,7 @@ jobs:
   displayName: 'Build, Publish & Test'
   timeoutInMinutes: 60
   pool:
-    vmImage: windows-latest
+    vmImage: windows-2022
     demands:
     - msbuild
     - visualstudio

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -20,6 +20,8 @@ jobs:
   displayName: 'Build, Publish & Test'
   timeoutInMinutes: 60
   pool:
+    # Need to specify windows-2022 until windows-latest moves to Server 2022.
+    # We need Server 2022 to use the "winget" appExecutionAlias in the integration tests.
     vmImage: windows-2022
     demands:
     - msbuild

--- a/src/WinGet.RestSource.Functions/PackageFunctions.cs
+++ b/src/WinGet.RestSource.Functions/PackageFunctions.cs
@@ -191,7 +191,7 @@ namespace Microsoft.WinGet.RestSource.Functions
                 Dictionary<string, string> headers = HeaderProcessor.ToDictionary(req.Headers);
 
                 // Fetch Results
-                packages = await this.dataStore.GetPackages(packageIdentifier, req.Query[QueryConstants.ContinuationToken]);
+                packages = await this.dataStore.GetPackages(packageIdentifier, headers.GetValueOrDefault(QueryConstants.ContinuationToken));
             }
             catch (DefaultException e)
             {

--- a/src/WinGet.RestSource.Functions/PackageManifestFunctions.cs
+++ b/src/WinGet.RestSource.Functions/PackageManifestFunctions.cs
@@ -188,8 +188,8 @@ namespace Microsoft.WinGet.RestSource.Functions
             {
                 // Parse Headers
                 Dictionary<string, string> headers = HeaderProcessor.ToDictionary(req.Headers);
+                string continuationToken = headers.GetValueOrDefault(QueryConstants.ContinuationToken);
 
-                string continuationToken = null;
                 string versionFilter = null;
                 string channelFilter = null;
                 string marketFilter = null;
@@ -197,7 +197,6 @@ namespace Microsoft.WinGet.RestSource.Functions
                 // Schema supports query parameters only when PackageIdentifier is specified.
                 if (!string.IsNullOrWhiteSpace(packageIdentifier))
                 {
-                    continuationToken = req.Query[QueryConstants.ContinuationToken];
                     versionFilter = req.Query[QueryConstants.Version];
                     channelFilter = req.Query[QueryConstants.Channel];
                     marketFilter = req.Query[QueryConstants.Market];

--- a/src/WinGet.RestSource.IntegrationTest/Common/TestsBase.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Common/TestsBase.cs
@@ -1,0 +1,60 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="TestsBase.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.IntegrationTest
+{
+    using System;
+    using Microsoft.Extensions.Configuration;
+    using Xunit.Abstractions;
+    using Xunit.Sdk;
+
+    public abstract class TestsBase
+    {
+        protected const string PowerToysPackageIdentifier = "Microsoft.PowerToys";
+        protected readonly ITestOutputHelper log;
+        protected readonly string restSourceName;
+        protected readonly string restSourceUrl;
+        protected readonly string functionsMasterKey;
+        protected readonly bool addRestSource;
+        protected readonly bool RunWriteTests;
+
+        public TestsBase(ITestOutputHelper log)
+        {
+            this.log = log;
+
+            var configuration = new ConfigurationBuilder()
+
+                // Defaults specified in the Test.runsettings.json
+                .AddJsonFile("Test.runsettings.json", true)
+
+                // But they can be overridden using environment variables
+                .AddEnvironmentVariables()
+                .Build();
+
+            const string restSourceNameKey = "RestSourceName";
+            const string restSourceUrlKey = "RestSourceUrl";
+            const string addRestSourceKey = "AddRestSource";
+            const string RunWriteTestsKey = "RunWriteTests";
+            const string functionsMasterKeyKey = "FunctionsMasterKey";
+            this.restSourceName = configuration[restSourceNameKey] ?? throw new NullException(restSourceNameKey);
+            this.restSourceUrl = configuration[restSourceUrlKey] ?? throw new NullException(restSourceUrlKey);
+            this.functionsMasterKey = configuration[functionsMasterKeyKey] ?? throw new NullException(functionsMasterKeyKey);
+            this.addRestSource = bool.TryParse(configuration[addRestSourceKey], out bool addRestSource) && addRestSource;
+            this.RunWriteTests = bool.TryParse(configuration[RunWriteTestsKey], out bool RunWriteTests) && RunWriteTests;
+
+            this.log.WriteLine($"{restSourceNameKey}: {this.restSourceName}");
+            this.log.WriteLine($"{restSourceUrlKey}: {this.restSourceUrl}");
+            this.log.WriteLine($"{functionsMasterKeyKey}: {this.functionsMasterKey}");
+            this.log.WriteLine($"{addRestSourceKey}: {this.addRestSource}");
+            this.log.WriteLine($"{RunWriteTestsKey}: {this.RunWriteTests}");
+
+            if (this.RunWriteTests && string.IsNullOrEmpty(this.functionsMasterKey))
+            {
+                throw new ArgumentException($"RunWriteTests is set to true, but FunctionsMasterKey is not set");
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource.IntegrationTest/Common/TestsBase.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Common/TestsBase.cs
@@ -11,19 +11,23 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest
     using Xunit.Abstractions;
     using Xunit.Sdk;
 
+    /// <summary>
+    /// Base class used for all integration tests.
+    /// </summary>
     public abstract class TestsBase
     {
+        /// <summary>
+        /// Package Identifier of app to use for testing, must be present in repository.
+        /// </summary>
         protected const string PowerToysPackageIdentifier = "Microsoft.PowerToys";
-        protected readonly ITestOutputHelper log;
-        protected readonly string restSourceName;
-        protected readonly string restSourceUrl;
-        protected readonly string functionsMasterKey;
-        protected readonly bool addRestSource;
-        protected readonly bool RunWriteTests;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TestsBase"/> class.
+        /// </summary>
+        /// <param name="log">Logger to use for tests.</param>
         public TestsBase(ITestOutputHelper log)
         {
-            this.log = log;
+            this.Log = log;
 
             var configuration = new ConfigurationBuilder()
 
@@ -38,23 +42,53 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest
             const string restSourceUrlKey = "RestSourceUrl";
             const string addRestSourceKey = "AddRestSource";
             const string RunWriteTestsKey = "RunWriteTests";
-            const string functionsMasterKeyKey = "FunctionsMasterKey";
-            this.restSourceName = configuration[restSourceNameKey] ?? throw new NullException(restSourceNameKey);
-            this.restSourceUrl = configuration[restSourceUrlKey] ?? throw new NullException(restSourceUrlKey);
-            this.functionsMasterKey = configuration[functionsMasterKeyKey] ?? throw new NullException(functionsMasterKeyKey);
-            this.addRestSource = bool.TryParse(configuration[addRestSourceKey], out bool addRestSource) && addRestSource;
-            this.RunWriteTests = bool.TryParse(configuration[RunWriteTestsKey], out bool RunWriteTests) && RunWriteTests;
+            const string functionsHostKeyKey = "FunctionsHostKey";
+            this.RestSourceName = configuration[restSourceNameKey] ?? throw new NullException(restSourceNameKey);
+            this.RestSourceUrl = configuration[restSourceUrlKey] ?? throw new NullException(restSourceUrlKey);
+            this.FunctionsHostKey = configuration[functionsHostKeyKey] ?? throw new NullException(functionsHostKeyKey);
+            this.AddRestSource = bool.TryParse(configuration[addRestSourceKey], out bool addRestSource) && addRestSource;
+            this.RunWriteTests = bool.TryParse(configuration[RunWriteTestsKey], out bool runWriteTests) && runWriteTests;
 
-            this.log.WriteLine($"{restSourceNameKey}: {this.restSourceName}");
-            this.log.WriteLine($"{restSourceUrlKey}: {this.restSourceUrl}");
-            this.log.WriteLine($"{functionsMasterKeyKey}: {this.functionsMasterKey}");
-            this.log.WriteLine($"{addRestSourceKey}: {this.addRestSource}");
-            this.log.WriteLine($"{RunWriteTestsKey}: {this.RunWriteTests}");
+            this.Log.WriteLine($"{restSourceNameKey}: {this.RestSourceName}");
+            this.Log.WriteLine($"{restSourceUrlKey}: {this.RestSourceUrl}");
+            this.Log.WriteLine($"{functionsHostKeyKey}: {this.FunctionsHostKey}");
+            this.Log.WriteLine($"{addRestSourceKey}: {this.AddRestSource}");
+            this.Log.WriteLine($"{RunWriteTestsKey}: {this.RunWriteTests}");
 
-            if (this.RunWriteTests && string.IsNullOrEmpty(this.functionsMasterKey))
+            if (this.RunWriteTests && string.IsNullOrEmpty(this.FunctionsHostKey))
             {
-                throw new ArgumentException($"RunWriteTests is set to true, but FunctionsMasterKey is not set");
+                throw new ArgumentException($"RunWriteTests is set to true, but FunctionsHostKey is not set");
             }
         }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to add the rest source to winget as part of the test execution.
+        /// </summary>
+        protected bool AddRestSource { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether or not to run tests which modify the repository.
+        /// </summary>
+        protected bool RunWriteTests { get; }
+
+        /// <summary>
+        /// Gets the functions host key to use for tests that modify the repository.
+        /// </summary>
+        protected string FunctionsHostKey { get; }
+
+        /// <summary>
+        /// Gets the url for the rest source function app to use for integration tests.
+        /// </summary>
+        protected string RestSourceUrl { get; }
+
+        /// <summary>
+        /// Gets the rest source name to use with the winget client.
+        /// </summary>
+        protected string RestSourceName { get; }
+
+        /// <summary>
+        /// Gets the logger to use for tests.
+        /// </summary>
+        protected ITestOutputHelper Log { get; }
     }
 }

--- a/src/WinGet.RestSource.IntegrationTest/Test.runsettings.template.json
+++ b/src/WinGet.RestSource.IntegrationTest/Test.runsettings.template.json
@@ -1,7 +1,7 @@
 ﻿{
-    "RestSourceName": "winget-pkgs-restsource",
+    "RestSourceName": "winget-cli-restsource",
     "RestSourceUrl": "https://localhost:7071/api",
     "AddRestSource": "false",
     "RunWriteTests": "false",
-    "FunctionsMasterKey": null
+    "FunctionsHostKey": null
 }

--- a/src/WinGet.RestSource.IntegrationTest/Test.runsettings.template.json
+++ b/src/WinGet.RestSource.IntegrationTest/Test.runsettings.template.json
@@ -1,0 +1,7 @@
+﻿{
+    "RestSourceName": "winget-pkgs-restsource",
+    "RestSourceUrl": "https://localhost:7071/api",
+    "AddRestSource": "false",
+    "RunWriteTests": "false",
+    "FunctionsMasterKey": null
+}

--- a/src/WinGet.RestSource.IntegrationTest/Tests/Functions/FunctionsTests.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Tests/Functions/FunctionsTests.cs
@@ -1,0 +1,332 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="FunctionsTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.IntegrationTest.Functions
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    using Flurl;
+    using Flurl.Http;
+    using Microsoft.WinGet.RestSource.Utils.Common;
+    using Microsoft.WinGet.RestSource.Utils.Constants;
+    using Microsoft.WinGet.RestSource.Utils.Constants.Enumerations;
+    using Microsoft.WinGet.RestSource.Utils.Models;
+    using Microsoft.WinGet.RestSource.Utils.Models.ExtendedSchemas;
+    using Microsoft.WinGet.RestSource.Utils.Models.Schemas;
+    using Newtonsoft.Json;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// CosmosDataStore Tests.
+    /// </summary>
+    public class FunctionsTests : TestsBase, IAsyncLifetime
+    {
+        private const int MaxResultsPerPage = 20;
+        private readonly string packagesUrl;
+        private readonly string packageManifestsUrl;
+        private readonly string powerToysPackageManifestUrl;
+        private readonly string powerToysPackageUrl;
+        private string powerToysManifestJson;
+        private bool modifiedManifest;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FunctionsTests"/> class.
+        /// </summary>
+        /// <param name="log">ITestOutputHelper.</param>
+        public FunctionsTests(ITestOutputHelper log)
+            : base(log)
+        {
+            this.packagesUrl = this.restSourceUrl.AppendPathSegment("packages");
+            this.packageManifestsUrl = this.restSourceUrl.AppendPathSegment("packageManifests");
+            this.powerToysPackageManifestUrl = this.packageManifestsUrl.AppendPathSegment(PowerToysPackageIdentifier);
+            this.powerToysPackageUrl = this.packagesUrl.AppendPathSegment(PowerToysPackageIdentifier);
+        }
+
+        /// <inheritdoc/>
+        public async Task InitializeAsync()
+        {
+            // Store PowerToys manifest so we can ensure it's re-added at the end.
+            var packageManifests = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            if (packageManifests == null)
+            {
+                throw new System.IO.InvalidDataException($"{PowerToysPackageIdentifier} isn't present in REST source. Populate source prior to running tests");
+            }
+            else
+            {
+                var powerToysManifest = packageManifests.Data.SingleOrDefault();
+                this.powerToysManifestJson = JsonConvert.SerializeObject(powerToysManifest);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task DisposeAsync()
+        {
+            // Restore the PowerToys manifest from backup if necessary.
+            if (this.modifiedManifest)
+            {
+                await this.RunAndTestProtectedApi(this.powerToysPackageManifestUrl, HttpMethod.Delete);
+                await this.RunAndTestProtectedApi(this.packageManifestsUrl, HttpMethod.Post, this.powerToysManifestJson);
+            }
+        }
+
+        private async Task RunAndTestProtectedApi(string url, HttpMethod httpMethod, object data = null)
+        {
+            Func<string, Task> method = data == null ?
+                (url => url.SendAsync(httpMethod)) :
+                    data is string str ?
+                        (url => url.SendStringAsync(httpMethod, str)) :
+                        (url => url.SendJsonAsync(httpMethod, data));
+
+            // Protected API should fail without an authorization code.
+            await Assert.ThrowsAsync<FlurlHttpException>(() => method(url));
+
+            // Should succeed once the authorization key is added.
+            await method(url.SetQueryParam("code", this.functionsMasterKey));
+        }
+
+        /// <summary>
+        /// Verifies the various CRUD operations exposed by the API.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [SkippableFact]
+        public async Task CreateUpdateReadDeleteTest()
+        {
+            // Only run this test if the setting is explicitly set.
+            Skip.IfNot(this.RunWriteTests);
+
+            var packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            PackageManifest addedManifest = packageManifestsResult.Data.Single();
+
+            // Start by deleting the manifest from the source and verify it's gone.
+            await this.RunAndTestProtectedApi(this.powerToysPackageManifestUrl, HttpMethod.Delete);
+            this.modifiedManifest = true;
+            packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            Assert.Null(packageManifestsResult);
+
+            // Now add it and verify it's present.
+            await this.RunAndTestProtectedApi(this.packageManifestsUrl, HttpMethod.Post, addedManifest);
+            packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            Assert.Equal(PowerToysPackageIdentifier, packageManifestsResult.Data.Single().PackageIdentifier);
+
+            // Now update it and verify that it got updated.
+            string updatedName = "BOGUS_NAME";
+            addedManifest.Versions.First().DefaultLocale.PackageName = updatedName;
+            await this.RunAndTestProtectedApi(this.powerToysPackageManifestUrl, HttpMethod.Put, addedManifest);
+            packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            Assert.Equal(updatedName, packageManifestsResult.Data.Single().Versions.First().DefaultLocale.PackageName);
+
+            // Now delete it, and verify it's gone.
+            await this.RunAndTestProtectedApi(this.powerToysPackageManifestUrl, HttpMethod.Delete);
+            packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            Assert.Null(packageManifestsResult);
+
+            // Now add just the package, and verify it's present.
+            await this.RunAndTestProtectedApi(this.packagesUrl, HttpMethod.Post, addedManifest);
+            var packageResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageUrl);
+            Assert.Equal(PowerToysPackageIdentifier, packageResult.Data.Single().PackageIdentifier);
+
+            // Now add a version, installer, and locale to the package.
+            VersionExtended addedVersion = addedManifest.Versions.First();
+            string versionsUrl = this.powerToysPackageUrl.AppendPathSegment("versions");
+            await this.RunAndTestProtectedApi(versionsUrl, HttpMethod.Post, addedVersion);
+            string versionUrl = versionsUrl.AppendPathSegment(addedVersion.PackageVersion);
+            await this.RunAndTestProtectedApi(versionUrl.AppendPathSegment("installers"), HttpMethod.Post, addedVersion.Installers.First());
+            await this.RunAndTestProtectedApi(versionUrl.AppendPathSegment("locales"), HttpMethod.Post, addedVersion.DefaultLocale);
+
+            // Verify that everything got added correctly.
+            packageManifestsResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+            var resultVersion = packageManifestsResult.Data.First().Versions.First();
+            Assert.Equal(addedVersion.PackageVersion, resultVersion.PackageVersion);
+            Assert.Equal(addedVersion.DefaultLocale.PackageName, resultVersion.DefaultLocale.PackageName);
+            Assert.Equal(addedVersion.Installers.First().InstallerUrl, resultVersion.Installers.First().InstallerUrl);
+
+            // Delete the package using the packages API, and verify it's gone.
+            await this.RunAndTestProtectedApi(this.powerToysPackageUrl, HttpMethod.Delete);
+            packageResult = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageUrl);
+            Assert.Null(packageResult);
+
+            // Lastly, re-add the original copy.
+            await this.RunAndTestProtectedApi(this.packageManifestsUrl, HttpMethod.Post, this.powerToysManifestJson);
+            this.modifiedManifest = false;
+        }
+
+        /// <summary>
+        /// Verifies the GetPackage* APIs.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetPackages()
+        {
+            this.log.WriteLine("Tests that GetPackages returns the expected package.");
+            {
+                var packages = await GetConsistentApiResponse<Package>(this.powerToysPackageUrl);
+                Assert.NotEmpty(packages.Data);
+                Assert.Equal(PowerToysPackageIdentifier, packages.Data.First().PackageIdentifier);
+            }
+
+            this.log.WriteLine("Tests that ContinuationToken has an effect for GetPackages.");
+            {
+                var firstPackageSet = await GetConsistentApiResponse<Package>(this.packagesUrl);
+                Assert.Equal(MaxResultsPerPage, firstPackageSet.Data.Count);
+
+                var continuedPackageSet = await GetConsistentApiResponse<Package>(this.packagesUrl.WithHeader(HeaderConstants.ContinuationToken, firstPackageSet.ContinuationToken));
+                Assert.Equal(MaxResultsPerPage, continuedPackageSet.Data.Count);
+                Assert.False(firstPackageSet.Data.Intersect(continuedPackageSet.Data).Any());
+            }
+
+            this.log.WriteLine("Tests that GetPackageManifests returns the expected package.");
+            {
+                var packageManifests = await GetConsistentApiResponse<PackageManifest>(this.powerToysPackageManifestUrl);
+                Assert.NotEmpty(packageManifests.Data);
+                Assert.Equal(PowerToysPackageIdentifier, packageManifests.Data.First().PackageIdentifier);
+            }
+
+            this.log.WriteLine("Tests that GetPackageManifests returns the expected package and version.");
+            {
+                const string version = "0.37.0";
+                var packageManifests = await GetConsistentApiResponse<PackageManifest>(
+                    this.restSourceUrl
+                    .AppendPathSegment("packageManifests")
+                    .AppendPathSegment(PowerToysPackageIdentifier)
+                    .SetQueryParam("Version", version));
+                Assert.NotEmpty(packageManifests.Data);
+                Assert.Equal(PowerToysPackageIdentifier, packageManifests.Data.First().PackageIdentifier);
+                Assert.Equal(version, packageManifests.Data.First().Versions.Single().PackageVersion);
+            }
+
+            this.log.WriteLine("Tests that ContinuationToken has an effect for GetPackageManifests.");
+            {
+                var firstPackageManifestSet = await GetConsistentApiResponse<Package>(this.packageManifestsUrl);
+                Assert.Equal(MaxResultsPerPage, firstPackageManifestSet.Data.Count);
+
+                var continuedPackageManifestSet = await GetConsistentApiResponse<Package>(this.packageManifestsUrl.WithHeader(HeaderConstants.ContinuationToken, firstPackageManifestSet.ContinuationToken));
+                Assert.Equal(MaxResultsPerPage, continuedPackageManifestSet.Data.Count);
+                Assert.False(firstPackageManifestSet.Data.Intersect(continuedPackageManifestSet.Data).Any());
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the search API correctly handles a search using a search query term.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SearchUsingQuery()
+        {
+            this.log.WriteLine("Tests that SearchPackageManifests returns the expected results when using the Query property.");
+            {
+                await this.TestSearchQuery("PowerToys", MatchType.Exact, PowerToysPackageIdentifier);
+                await this.TestSearchQuery("powertoys", MatchType.CaseInsensitive, PowerToysPackageIdentifier);
+                await this.TestSearchQuery("PowerT", MatchType.StartsWith, PowerToysPackageIdentifier);
+                await this.TestSearchQuery("owertoy", MatchType.Substring, PowerToysPackageIdentifier);
+                await this.TestSearchQuery("nonexistentpackage", MatchType.Substring);
+            }
+
+            this.log.WriteLine("Tests that using ContinuationToken with SearchPackageManifests allows us to retrieve all manifests.");
+            {
+                var allResults = new HashSet<ManifestSearchResponse>();
+                string continuationToken = null;
+                do
+                {
+                    var manifestSearchRequest = new ManifestSearchRequest();
+                    var result = await this.GetSearchResults(manifestSearchRequest, continuationToken);
+                    allResults.UnionWith(result.Data);
+                    continuationToken = result.ContinuationToken;
+                }
+                while (continuationToken != null);
+                Assert.True(allResults.Count > MaxResultsPerPage);
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the API correctly handles a search using filters.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task SearchUsingFilter()
+        {
+            await this.TestSearchFilter(PackageMatchFields.PackageName, "PowerToys", MatchType.Exact, PowerToysPackageIdentifier);
+            await this.TestSearchFilter(PackageMatchFields.PackageName, "powertoys", MatchType.CaseInsensitive, PowerToysPackageIdentifier);
+            await this.TestSearchFilter(PackageMatchFields.PackageName, "PowerT", MatchType.StartsWith, PowerToysPackageIdentifier);
+            await this.TestSearchFilter(PackageMatchFields.PackageName, "owertoy", MatchType.Substring, PowerToysPackageIdentifier);
+            await this.TestSearchFilter(PackageMatchFields.PackageName, "nonexistentpackage", MatchType.Substring);
+        }
+
+        private static void VerifyResult(SearchApiResponse<List<ManifestSearchResponse>> results, params string[] expectedPackageIdentifiers)
+        {
+            Assert.Equal(expectedPackageIdentifiers.Length, results.Data.Count);
+            var packageIdentifierResults = results.Data.Select(i => i.PackageIdentifier).ToList();
+            foreach (var expectedPackageIdentifier in expectedPackageIdentifiers)
+            {
+                Assert.Contains(expectedPackageIdentifier, packageIdentifierResults);
+            }
+        }
+
+        private static async Task<ApiResponse<List<T>>> GetConsistentApiResponse<T>(string url)
+        {
+            return await GetConsistentApiResponse<T>(new FlurlRequest(url));
+        }
+
+        private static async Task<ApiResponse<List<T>>> GetConsistentApiResponse<T>(IFlurlRequest url)
+        {
+            string json = await url.GetStringAsync();
+
+            try
+            {
+                return JsonConvert.DeserializeObject<ApiResponse<List<T>>>(json);
+            }
+            catch (JsonSerializationException)
+            {
+                var singleResult = JsonConvert.DeserializeObject<ApiResponse<T>>(json);
+                return new ApiResponse<List<T>>(new List<T> { singleResult.Data });
+            }
+        }
+
+        private async Task<SearchApiResponse<List<ManifestSearchResponse>>> GetSearchResults(ManifestSearchRequest manifestSearchRequest, string continuationToken = null)
+        {
+            string url = this.restSourceUrl.AppendPathSegment("manifestSearch");
+
+            IFlurlResponse response;
+            if (continuationToken != null)
+            {
+                response = await url.WithHeader(HeaderConstants.ContinuationToken, continuationToken).PostJsonAsync(manifestSearchRequest);
+            }
+            else
+            {
+                response = await url.PostJsonAsync(manifestSearchRequest);
+            }
+
+            return await response.GetJsonAsync<SearchApiResponse<List<ManifestSearchResponse>>>();
+        }
+
+        private async Task TestSearchQuery(string value, string matchType, params string[] expectedPackageIdentifiers)
+        {
+            var manifestSearchRequest = new ManifestSearchRequest();
+            manifestSearchRequest.Query = new RestSource.Utils.Models.Objects.SearchRequestMatch();
+            manifestSearchRequest.Query.KeyWord = value;
+            manifestSearchRequest.Query.MatchType = matchType;
+            var results = await this.GetSearchResults(manifestSearchRequest);
+            VerifyResult(results, expectedPackageIdentifiers);
+        }
+
+        private async Task TestSearchFilter(string packageMatchField, string value, string matchType, params string[] expectedPackageIdentifiers)
+        {
+            var manifestSearchRequest = new ManifestSearchRequest();
+            manifestSearchRequest.Filters = new RestSource.Utils.Models.Arrays.SearchRequestPackageMatchFilter
+            {
+                new RestSource.Utils.Models.Objects.SearchRequestPackageMatchFilter { PackageMatchField = packageMatchField, RequestMatch = new RestSource.Utils.Models.Objects.SearchRequestMatch { KeyWord = value, MatchType = matchType } },
+            };
+
+            var results = await this.GetSearchResults(manifestSearchRequest);
+            VerifyResult(results, expectedPackageIdentifiers);
+        }
+    }
+}

--- a/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
         /// <inheritdoc/>
         public async Task InitializeAsync()
         {
-            if (this.addRestSource)
+            if (this.AddRestSource)
             {
                 // Must be running as admin to succeed.
                 await this.AddSource();
@@ -42,7 +42,7 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
         /// <inheritdoc/>
         public async Task DisposeAsync()
         {
-            if (this.addRestSource)
+            if (this.AddRestSource)
             {
                 // Must be running as admin to succeed.
                 await this.RemoveSource();
@@ -99,6 +99,14 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
                 return Enumerable.Empty<WingetApp>();
             }
 
+            /* Output expected to be in this format:
+                Name                              Id                                      Version          Match
+                ----------------------------------------------------------------------------------------------------------
+                PowerToys (Preview)               Microsoft.PowerToys                     0.51.0
+                PowerShell Preview                Microsoft.PowerShell.Preview            7.2.0.10
+                PowerShell                        Microsoft.PowerShell                    7.2.0.0
+                Microsoft PowerApps CLI           Microsoft.PowerAppsCLI                  1.0
+            */
             return rows
                 .Skip(2)
                 .Select(r =>
@@ -127,7 +135,7 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
 
         private async Task TestWingetQuery(string query, Func<string, bool> validator, params string[] expectedPackageIdentifiers)
         {
-            string output = await RunWinget($"{query} -s {this.restSourceName}");
+            string output = await RunWinget($"{query} -s {this.RestSourceName}");
             if (validator != null)
             {
                 Assert.True(validator(output));
@@ -143,12 +151,12 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
         private async Task AddSource()
         {
             await this.RemoveSource();
-            await RunWinget($"source add -n {this.restSourceName} -a {this.restSourceUrl} -t \"Microsoft.Rest\"", CommandResultValidation.ZeroExitCode);
+            await RunWinget($"source add -n {this.RestSourceName} -a {this.RestSourceUrl} -t \"Microsoft.Rest\"", CommandResultValidation.ZeroExitCode);
         }
 
         private async Task RemoveSource()
         {
-            await RunWinget($"source remove {this.restSourceName}");
+            await RunWinget($"source remove {this.RestSourceName}");
         }
 
         private record WingetApp(string Name, string Id, string Version);

--- a/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
@@ -1,0 +1,156 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="WingetTests.cs" company="Microsoft Corporation">
+//     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using CliWrap;
+    using CliWrap.Buffered;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// E2E tests that use the winget client to test the REST service.
+    /// </summary>
+    public class WingetTests : TestsBase, IAsyncLifetime
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WingetTests"/> class.
+        /// </summary>
+        /// <param name="log">ITestOutputHelper.</param>
+        public WingetTests(ITestOutputHelper log)
+            : base(log)
+        {
+        }
+
+        /// <inheritdoc/>
+        public async Task InitializeAsync()
+        {
+            if (this.addRestSource)
+            {
+                // Must be running as admin to succeed.
+                await this.AddSource();
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task DisposeAsync()
+        {
+            if (this.addRestSource)
+            {
+                // Must be running as admin to succeed.
+                await this.RemoveSource();
+            }
+        }
+
+        /// <summary>
+        /// Tests winget's upgrade command against the REST api.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WingetUpgrade()
+        {
+            await this.TestWingetQuery("upgrade Microsoft.PowerShell", output => output.Contains("No applicable update found."));
+            await this.TestWingetQuery("upgrade Microsoft.PowerShelllll", output => output.Contains("No installed package found matching input criteria."));
+        }
+
+        /// <summary>
+        /// Tests winget's list command against the REST api.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WingetList()
+        {
+            await this.TestWingetQuery("list \"Windows Software Development Kit\"", output => output.Contains("Microsoft.WindowsSDK"));
+        }
+
+        /// <summary>
+        /// Tests winget's search command against the REST api.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task WingetSearch()
+        {
+            await this.TestWingetSearchQuery("PowerToys", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("powertoys", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("PowerT", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("owertoy", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("nonexistentpackage");
+
+            await this.TestWingetSearchQuery("--name PowerToys", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("--name powertoys", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("--name PowerT", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("--name owertoy", PowerToysPackageIdentifier);
+            await this.TestWingetSearchQuery("--name nonexistentpackage");
+        }
+
+        private static IEnumerable<WingetApp> ParseWingetOutput(string output)
+        {
+            var rows = output.Split(Environment.NewLine);
+
+            if (rows[0].Contains("No package found matching input criteria."))
+            {
+                return Enumerable.Empty<WingetApp>();
+            }
+
+            return rows
+                .Skip(2)
+                .Select(r =>
+                {
+                    var props = r.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    return props.Length == 3 ? new WingetApp(props[0], props[1], props[2]) : null;
+                })
+                .Where(r => r != null)
+                .ToList();
+        }
+
+        private static async Task<string> RunWinget(string arguments, CommandResultValidation commandResultValidation = CommandResultValidation.None)
+        {
+            var result = await Cli.Wrap(@"winget")
+            .WithArguments(arguments)
+            .WithValidation(commandResultValidation)
+            .ExecuteBufferedAsync();
+
+            return result.StandardOutput ?? result.StandardError;
+        }
+
+        private async Task TestWingetSearchQuery(string query, params string[] expectedPackageIdentifiers)
+        {
+            await this.TestWingetQuery($"search {query}", null, expectedPackageIdentifiers);
+        }
+
+        private async Task TestWingetQuery(string query, Func<string, bool> validator, params string[] expectedPackageIdentifiers)
+        {
+            string output = await RunWinget($"{query} -s {this.restSourceName}");
+            if (validator != null)
+            {
+                Assert.True(validator(output));
+            }
+            else
+            {
+                var results = ParseWingetOutput(output);
+                var validators = expectedPackageIdentifiers.Select(id => (Action<WingetApp>)((WingetApp app) => Assert.Equal(id, app.Id))).ToArray();
+                Assert.Collection(results, validators);
+            }
+        }
+
+        private async Task AddSource()
+        {
+            await this.RemoveSource();
+            await RunWinget($"source add -n {this.restSourceName} -a {this.restSourceUrl} -t \"Microsoft.Rest\"", CommandResultValidation.ZeroExitCode);
+        }
+
+        private async Task RemoveSource()
+        {
+            await RunWinget($"source remove {this.restSourceName}");
+        }
+
+        private record WingetApp(string Name, string Id, string Version);
+    }
+}

--- a/src/WinGet.RestSource.IntegrationTest/WinGet.RestSource.IntegrationTest.csproj
+++ b/src/WinGet.RestSource.IntegrationTest/WinGet.RestSource.IntegrationTest.csproj
@@ -1,0 +1,62 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <AssemblyName>Microsoft.WinGet.RestSource.IntegrationTest</AssemblyName>
+    <RootNamespace>Microsoft.WinGet.RestSource.IntegrationTest</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <DebugSymbols>true</DebugSymbols>
+    <NoWarn>1701;1702;NU1701</NoWarn>
+    <DocumentationFile>Microsoft.Winget.RestSource.IntegrationTest.Documentation.xml</DocumentationFile>
+    <UserSecretsId>09404207-b3a3-4757-83f3-0a1ec9c39c4a</UserSecretsId>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <DebugType>full</DebugType>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <WarningsAsErrors />
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Flurl.Http" Version="3.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <AdditionalFiles Include="..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="CliWrap" Version="3.3.3" />
+    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\WinGet.RestSource.Utils\WinGet.RestSource.Utils.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Test.runsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+    <None Update="Test.runsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/src/WinGet.RestSource.UnitTest/Tests/RestSource/Cosmos/CosmosDataStoreTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/RestSource/Cosmos/CosmosDataStoreTests.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
         private const string PowerToysPackageIdentifier = "Microsoft.PowerToys";
 
         private readonly ITestOutputHelper log;
-        private readonly IConfigurationRoot configuration;
         private readonly CosmosDataStore cosmosDataStore;
         private IList<CosmosPackageManifest> allTestManifests;
 
@@ -49,7 +48,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
         {
             this.log = log;
 
-            this.configuration = new ConfigurationBuilder()
+            var configuration = new ConfigurationBuilder()
 
                 // Defaults specified in the Test.runsettings.json
                 .AddJsonFile("Test.runsettings.json", true)
@@ -58,11 +57,11 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
                 .AddEnvironmentVariables()
                 .Build();
 
-            string endpoint = this.configuration[CosmosConnectionConstants.CosmosAccountEndpointSetting] ?? throw new ArgumentNullException();
-            string readOnlyKey = this.configuration[CosmosConnectionConstants.CosmosReadOnlyKeySetting] ?? throw new ArgumentNullException();
-            string readWriteKey = this.configuration[CosmosConnectionConstants.CosmosReadWriteKeySetting] ?? throw new ArgumentNullException();
-            string databaseId = this.configuration[CosmosConnectionConstants.DatabaseNameSetting] ?? throw new ArgumentNullException();
-            string containerId = this.configuration[CosmosConnectionConstants.ContainerNameSetting] ?? throw new ArgumentNullException();
+            string endpoint = configuration[CosmosConnectionConstants.CosmosAccountEndpointSetting] ?? throw new ArgumentNullException();
+            string readOnlyKey = configuration[CosmosConnectionConstants.CosmosReadOnlyKeySetting] ?? throw new ArgumentNullException();
+            string readWriteKey = configuration[CosmosConnectionConstants.CosmosReadWriteKeySetting] ?? throw new ArgumentNullException();
+            string databaseId = configuration[CosmosConnectionConstants.DatabaseNameSetting] ?? throw new ArgumentNullException();
+            string containerId = configuration[CosmosConnectionConstants.ContainerNameSetting] ?? throw new ArgumentNullException();
 
             this.log.WriteLine($"{CosmosConnectionConstants.CosmosAccountEndpointSetting}: {endpoint}");
             this.log.WriteLine($"{CosmosConnectionConstants.CosmosReadOnlyKeySetting}: {readOnlyKey}");
@@ -168,7 +167,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
             this.log.WriteLine("Tests that GetPackages returns the expected package.");
             {
                 var packages = await this.cosmosDataStore.GetPackages(PowerToysPackageIdentifier, null);
-                Assert.NotEqual(0, packages.Items.Count);
+                Assert.NotEmpty(packages.Items);
                 Assert.Equal(PowerToysPackageIdentifier, packages.Items.First().PackageIdentifier);
             }
 
@@ -185,7 +184,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
             this.log.WriteLine("Tests that GetPackageManifests returns the expected package.");
             {
                 var packageManifests = await this.cosmosDataStore.GetPackageManifests(PowerToysPackageIdentifier);
-                Assert.NotEqual(0, packageManifests.Items.Count);
+                Assert.NotEmpty(packageManifests.Items);
                 Assert.Equal(PowerToysPackageIdentifier, packageManifests.Items.First().PackageIdentifier);
             }
 
@@ -193,7 +192,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Cosmos
             {
                 const string version = "0.37.0";
                 var packageManifests = await this.cosmosDataStore.GetPackageManifests(PowerToysPackageIdentifier, null, version);
-                Assert.NotEqual(0, packageManifests.Items.Count);
+                Assert.NotEmpty(packageManifests.Items);
                 Assert.Equal(PowerToysPackageIdentifier, packageManifests.Items.First().PackageIdentifier);
                 Assert.Equal(version, packageManifests.Items.First().Versions.Single().PackageVersion);
             }

--- a/src/WinGet.RestSource.Utils/Models/Schemas/ManifestSearchRequest.cs
+++ b/src/WinGet.RestSource.Utils/Models/Schemas/ManifestSearchRequest.cs
@@ -6,12 +6,11 @@
 
 namespace Microsoft.WinGet.RestSource.Utils.Models.Schemas
 {
+    using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
-    using Microsoft.WinGet.RestSource.Utils.Constants;
     using Microsoft.WinGet.RestSource.Utils.Models.Core;
     using Microsoft.WinGet.RestSource.Utils.Validators;
-    using Microsoft.WinGet.RestSource.Utils.Validators.StringValidators;
 
     /// <summary>
     /// ManifestSearchRequest.
@@ -146,7 +145,7 @@ namespace Microsoft.WinGet.RestSource.Utils.Models.Schemas
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return (this.MaximumResults, this.FetchAllManifests, this.Query, this.Inclusions, this.Filters).GetHashCode();
+            return HashCode.Combine(this.MaximumResults, this.FetchAllManifests, this.Query, this.Inclusions, this.Filters);
         }
     }
 }

--- a/src/WinGet.RestSource.Utils/Models/Schemas/ManifestSearchResponse.cs
+++ b/src/WinGet.RestSource.Utils/Models/Schemas/ManifestSearchResponse.cs
@@ -339,7 +339,7 @@ namespace Microsoft.WinGet.RestSource.Utils.Models.Schemas
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return (this.PackageIdentifier, this.PackageName, this.Publisher, this.Versions).GetHashCode();
+            return HashCode.Combine(this.PackageIdentifier, this.PackageName, this.Publisher, this.Versions);
         }
     }
 }

--- a/src/WinGet.RestSource.sln
+++ b/src/WinGet.RestSource.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31729.503
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31825.309
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource", "WinGet.RestSource\WinGet.RestSource.csproj", "{15E4BE9B-2891-410A-A042-47FE838B1AEC}"
 EndProject
@@ -84,6 +84,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{5CA26277-F8C
 		..\doc\new-private-repository-azure.md = ..\doc\new-private-repository-azure.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource.IntegrationTest", "WinGet.RestSource.IntegrationTest\WinGet.RestSource.IntegrationTest.csproj", "{44AD7B2D-4367-47B0-987A-DABDF5C74A9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -114,6 +116,10 @@ Global
 		{0BB2CC46-C7C4-4944-843E-ADBE14CEF29B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BB2CC46-C7C4-4944-843E-ADBE14CEF29B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BB2CC46-C7C4-4944-843E-ADBE14CEF29B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{44AD7B2D-4367-47B0-987A-DABDF5C74A9B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{44AD7B2D-4367-47B0-987A-DABDF5C74A9B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{44AD7B2D-4367-47B0-987A-DABDF5C74A9B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{44AD7B2D-4367-47B0-987A-DABDF5C74A9B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Adding two new integration test suites
	- One tests directly against the REST endpoints, and includes write-operations
	- One tests indirectly against the REST endpoints by calling into the winget client
- Modifies the build pipeline to run new tests. The write-operation tests aren't run by default, we may decide to change this later. I had to update the pipeline to windows-2022 to get winget to run packaged.
- Fixed a bug where the Package* GET apis weren't correctly using the continuationToken.