### PR TITLE
Fix CliWrap usage

### DIFF
--- a/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
+++ b/src/WinGet.RestSource.IntegrationTest/Tests/Winget/WingetTests.cs
@@ -121,11 +121,14 @@ namespace Microsoft.WinGet.RestSource.IntegrationTest.Winget
         private static async Task<string> RunWinget(string arguments, CommandResultValidation commandResultValidation = CommandResultValidation.None)
         {
             var result = await Cli.Wrap(@"winget")
-            .WithArguments(arguments)
-            .WithValidation(commandResultValidation)
-            .ExecuteBufferedAsync();
+                .WithArguments(arguments)
+                .WithValidation(commandResultValidation)
+                .ExecuteBufferedAsync();
+                
+            if (!string.IsNullOrWhiteSpace(result.StandardOutput))
+                return result.StandardOutput;
 
-            return result.StandardOutput ?? result.StandardError;
+            return result.StandardError;
         }
 
         private async Task TestWingetSearchQuery(string query, params string[] expectedPackageIdentifiers)


### PR DESCRIPTION
`result.StandardOutput` and `result.StandardError` can never be null, so `string.IsNullOrWhiteSpace(...)` (or maybe `string.IsNullOrEmpty(...)` to be less greedy) is a better fit.