### PR TITLE
Revise Scripts to support running from a service principal context

### DIFF
--- a/Tools/PowershellModule/src/Library/New-ARMObjects.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMObjects.ps1
@@ -117,7 +117,7 @@ Function New-ARMObjects
                 }
                 ## Creating the object following the ARM template failed.
                 ## TODO: extend error reporting in logs across scripts.
-                Write-Error "Failed to create Azure object. ($Result.Error)" -TargetObject $ErrReturnObject
+                Write-Error "Failed to create Azure object. $($Result.Error)" -TargetObject $ErrReturnObject
                 Return
             }
             else {

--- a/Tools/PowershellModule/src/Library/New-ARMObjects.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMObjects.ps1
@@ -116,7 +116,8 @@ Function New-ARMObjects
                     JobError    = $Result.Error
                 }
                 ## Creating the object following the ARM template failed.
-                Write-Error "Failed to create Azure object." -TargetObject $ErrReturnObject
+                ## TODO: extend error reporting in logs across scripts.
+                Write-Error "Failed to create Azure object. ($Result.Error)" -TargetObject $ErrReturnObject
                 Return
             }
             else {

--- a/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
@@ -466,7 +466,9 @@ Function New-ARMParameterObject
         foreach ($object in $ARMObjects) {
             ## Converts the structure of the variable to a JSON file.
             Write-Verbose -Message "  Creating the Parameter file for $($Object.ObjectType) in the following location:`n    $($Object.ParameterPath)"
-            $Object.Parameters | ConvertTo-Json -Depth 7 | Out-File -FilePath $Object.ParameterPath -Force
+            $parameterFile = $Object.Parameters | ConvertTo-Json -Depth 7
+            $parameterFile| Out-File -FilePath $Object.ParameterPath -Force
+            Write-Verbose -Message "Parameter file: ($parameterFile)"
         }
     }
     END

--- a/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
@@ -129,7 +129,7 @@ Function New-ARMParameterObject
         {
             $AzObjectID = $(Get-AzADServicePrincipal -ApplicationId $AzContext.Account.ID).Id
         }
-        Write-Verbose -Message "Retrieved the Azure User Id: $AzObjectID"
+        Write-Verbose -Message "Retrieved the Azure Object Id: $AzObjectID"
         
         ## This is specific to the JSON file creation
         $JSONContentVersion = "1.0.0.0"

--- a/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
@@ -120,8 +120,8 @@ Function New-ARMParameterObject
         $AzTenantID            = $(Get-AzContext).Tenant.Id
         Write-Verbose -Message "Retrieved the Azure Tenant Id: $AzTenantID"
 
-        $AzDirectoryID         = $(Get-AzADUser -UserPrincipalName $(Get-AzContext).Account.ID).Id
-        Write-Verbose -Message "Retrieved the Azure User Id: $AzDirectoryId"
+        $AzObjectID         = $(Get-AzContext).Account.ID
+        Write-Verbose -Message "Retrieved the Azure User Id: $AzObjectID"
         
         ## This is specific to the JSON file creation
         $JSONContentVersion = "1.0.0.0"
@@ -162,7 +162,7 @@ Function New-ARMParameterObject
                             value = @(
                                 @{
                                     tenantId = $AzTenantID
-                                    objectID = $AzDirectoryID
+                                    objectID = $AzObjectID
                                     permissions = @{
                                         keys         = @()
                                         secrets      = @( "Get", "Set" )

--- a/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
@@ -127,7 +127,7 @@ Function New-ARMParameterObject
         }
         else
         {
-            $AzObjectID = $(Get-AzADServicePrinciple -ApplicationId $AzContext.Account.ID).Id
+            $AzObjectID = $(Get-AzADServicePrincipal -ApplicationId $AzContext.Account.ID).Id
         }
         Write-Verbose -Message "Retrieved the Azure User Id: $AzObjectID"
         

--- a/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
+++ b/Tools/PowershellModule/src/Library/New-ARMParameterObject.ps1
@@ -117,10 +117,18 @@ Function New-ARMParameterObject
         
         ## This is the Azure Key Vault Key used to store the Connection String to the Storage Account
         Write-Verbose -Message "Retrieving the Azure Tenant and User Id Information"
-        $AzTenantID            = $(Get-AzContext).Tenant.Id
+        $AzContext = $(Get-AzContext)
+        $AzTenantID = $AzContext.Tenant.Id
         Write-Verbose -Message "Retrieved the Azure Tenant Id: $AzTenantID"
 
-        $AzObjectID         = $(Get-AzContext).Account.ID
+        if ($AzContext.Account.type -eq "User")
+        {
+            $AzObjectID = $(Get-AzADUser -UserPrincipalName $AzContext.Account.ID).Id
+        }
+        else
+        {
+            $AzObjectID = $(Get-AzADServicePrinciple -ApplicationId $AzContext.Account.ID).Id
+        }
         Write-Verbose -Message "Retrieved the Azure User Id: $AzObjectID"
         
         ## This is specific to the JSON file creation

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -22,4 +22,5 @@ jobs:
   - template: templates/restore-build-sign-publish-test.yml
 
   # Run Compliance checks
-  - template: templates/compliance.yml
+  # TODO reenable before checkin
+  #- template: templates/compliance.yml

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -22,5 +22,4 @@ jobs:
   - template: templates/restore-build-sign-publish-test.yml
 
   # Run Compliance checks
-  # TODO reenable before checkin
-  #- template: templates/compliance.yml
+  - template: templates/compliance.yml

--- a/src/WinGet.RestSource.sln
+++ b/src/WinGet.RestSource.sln
@@ -43,7 +43,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "PowershellModule", "Powersh
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "doc", "doc", "{954044E2-C2B4-4F62-BE4B-D9FAF66B05C2}"
 	ProjectSection(SolutionItems) = preProject
-		..\Tools\PowershellModule\doc\new-private-repository-azure.md = ..\Tools\PowershellModule\doc\new-private-repository-azure.md
+		..\Tools\PowershellModule\doc\new-winget-rest-source-azure.md = ..\Tools\PowershellModule\doc\new-winget-rest-source-azure.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{3C510F11-3A5B-4E30-8189-05E87B7DE1F0}"


### PR DESCRIPTION
This change adjusts the object id lookup logic to distinguish between a user and service principal context.
This enables running the scripts from CI/CD environments.
Additionally, it increases the verbosity of verbose logging.