### PR TITLE
Fixed link + removed en-US in links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The REST functions can be run locally, but to use winget with them, the function
 1. In the `src\WinGet.RestSource.Functions` directory, run `generate_self_sign_cert.ps1` in PowerShell.
    * This will generate a test pfx and install it into the Root store.
    * It will automatically be used as the HTTPS cert during local execution, thanks to `launchSettings.json`
-2. Create a CosmosDB database instance in Azure, using either the above instructions, or [manually](https://docs.microsoft.com/en-us/azure/cosmos-db/sql/create-cosmosdb-resources-portal).
+2. Create a CosmosDB database instance in Azure, using either the above instructions, or [manually](https://docs.microsoft.com/azure/cosmos-db/sql/create-cosmosdb-resources-portal).
    * Navigate to the Keys section of your CosmosDB instance in the Azure portal to find your connection information.
    * If you've used the ARM templates as described above, your Database will be named `WinGet` and your Collection will be `Manifests`
 3. Copy `src\WinGet.RestSource.Functions\local.settings.template.json` to `local.settings.json` and populate required fields from the above Keys section.
@@ -35,7 +35,7 @@ Running tests are a great way to ensure that functionality is preserved across m
 
 ### Unit Testing Prerequisites
 
-* Install the [Cosmos DB Emulator](https://docs.microsoft.com/en-us/azure/cosmos-db/local-emulator?tabs=ssl-netstd21)
+* Install the [Cosmos DB Emulator](https://docs.microsoft.com/azure/cosmos-db/local-emulator?tabs=ssl-netstd21)
 * Copy the `WinGet.RestSource.UnitTest\Test.runsettings.template.json` template configuration to `Test.runsettings.json`
   * The defaults should work for your local Cosmos DB emulator instance. You can change the configuration to point to a Cosmos DB instance in Azure instead.
   * Alternatively, all of the test configuration properties can be set as environment variables. This is useful for overriding properties in an ADO build.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet), [Xamarin](https://github.com/xamarin), and [our GitHub organizations](https://opensource.microsoft.com/).
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/en-us/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
+If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://docs.microsoft.com/previous-versions/tn-archive/cc751383(v=technet.10)), please report it to us as described below.
 
 ## Reporting Security Issues
 
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in any Microsoft-owned re
 
 Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://msrc.microsoft.com/create-report).
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/en-us/msrc/pgp-key-msrc).
+If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://www.microsoft.com/msrc/pgp-key-msrc).
 
 You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
 
@@ -36,6 +36,6 @@ We prefer all communications to be in English.
 
 ## Policy
 
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/en-us/msrc/cvd).
+Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://www.microsoft.com/msrc/cvd).
 
 <!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/Tools/PowershellModule/doc/new-winget-rest-source-azure.md
+++ b/Tools/PowershellModule/doc/new-winget-rest-source-azure.md
@@ -96,7 +96,7 @@ The PowerShell Module must be re-imported each time the PowerShell window is clo
 2. After the above command has completed, copy and run the connection information provided for your newly created Windows Package Manager REST source to add to your winget client.
 
 > [!Note]
-> To prevent having to re-install this new PowerShell module each time, review the instructions in the [Installing a PowerShell Module on Microsoft Docs](https://docs.microsoft.compowershell/scripting/developer/module/installing-a-powershell-module?view=powershell-7.1)
+> To prevent having to re-install this new PowerShell module each time, review the instructions in the [Installing a PowerShell Module on Microsoft Docs](https://docs.microsoft.com/powershell/scripting/developer/module/installing-a-powershell-module?view=powershell-7.1)
 
 ### Add manifests to the REST source
 


### PR DESCRIPTION
Fixed a link along with removed `en-US` in links (excluding the `src/` folder).

I know not every link has different languages, but some do, so it's better to have the standard use of Microsoft links to be without `en-US`. If there is no other language, it will redirect to `en-US` anyway.