### PR TITLE
Add Initial .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root=true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+insert_final_newline = true
+charset = utf-8
+
+[*.{csproj,deployproj}]
+indent_size = 2

--- a/src/WinGet.RestSource.sln
+++ b/src/WinGet.RestSource.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\.gitignore = ..\.gitignore
 		NuGet.config = NuGet.config
 		stylecop.json = stylecop.json
+		..\.editorconfig = ..\.editorconfig
 	EndProjectSection
 EndProject
 Project("{151D2E53-A2C4-4D7D-83FE-D05416EBD58E}") = "WinGet.RestSource.Infrastructure", "WinGet.RestSource.Infrastructure\WinGet.RestSource.Infrastructure.deployproj", "{0F98E939-EC64-40DA-9630-336A40807BBE}"


### PR DESCRIPTION
This adds an initial .editorconfig to help keep consistent formatting throughout the project. To start this will add options for indentation, line endings, and encoding; but this may expand in the future.