### PR TITLE
Fix reading function key

### DIFF
--- a/src/WinGet.RestSource.Functions/SourceFunctions.cs
+++ b/src/WinGet.RestSource.Functions/SourceFunctions.cs
@@ -109,6 +109,7 @@ namespace Microsoft.WinGet.RestSource.Functions
                         inputHelper.ReferenceType,
                         this.restSourceTriggerFunction,
                         ApiConstants.ManifestCacheEndpoint,
+                        ApiConstants.AzureFunctionHostKey,
                         loggingContext);
 
                     taskResult = new SourceResultOutputHelper(SourceResultType.Success);
@@ -204,6 +205,7 @@ namespace Microsoft.WinGet.RestSource.Functions
                         inputHelper.SASReference,
                         inputHelper.ReferenceType,
                         this.restSourceTriggerFunction,
+                        ApiConstants.AzureFunctionHostKey,
                         loggingContext);
 
                     taskResult = new SourceResultOutputHelper(SourceResultType.Success);

--- a/src/WinGet.RestSource.Functions/Startup.cs
+++ b/src/WinGet.RestSource.Functions/Startup.cs
@@ -56,8 +56,7 @@ namespace Microsoft.WinGet.RestSource.Functions
             builder.Services.AddSingleton<IRebuild>((s) => RebuildFactory.InitializeRebuildInstance());
             builder.Services.AddSingleton<IUpdate>((s) => UpdateFactory.InitializeUpdateInstance());
             builder.Services.AddSingleton<IRestSourceTriggerFunction>((s) => new RestSourceTriggerFunctions(
-                ApiConstants.AzFuncRestSourceEndpoint,
-                ApiConstants.AzureFunctionHostKey));
+                ApiConstants.AzFuncRestSourceEndpoint));
 
             InjectTelemetryConfiguration(builder);
         }

--- a/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
@@ -394,6 +394,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
                     referenceType,
                     It.IsAny<IRestSourceTriggerFunction>(),
                     It.IsAny<string>(),
+                    It.IsAny<string>(),
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -447,6 +448,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
                     sasReference,
                     referenceType,
                     It.IsAny<IRestSourceTriggerFunction>(),
+                    It.IsAny<string>(),
                     It.IsAny<string>(),
                     It.IsAny<LoggingContext>()))
                 .Throws(new Exception())
@@ -504,6 +506,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
                     sasReference,
                     referenceType,
                     It.IsAny<IRestSourceTriggerFunction>(),
+                    It.IsAny<string>(),
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -560,6 +563,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
                     sasReference,
                     referenceType,
                     It.IsAny<IRestSourceTriggerFunction>(),
+                    It.IsAny<string>(),
                     It.IsAny<LoggingContext>()))
                 .Throws(new RestSourceCallException("message"))
                 .Verifiable();
@@ -617,6 +621,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
                     sasReference,
                     referenceType,
                     It.IsAny<IRestSourceTriggerFunction>(),
+                    It.IsAny<string>(),
                     It.IsAny<LoggingContext>()))
                 .Throws(new Exception())
                 .Verifiable();

--- a/src/WinGet.RestSource.UnitTest/Tests/RestSource/Helpers/RestSourceTriggerFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/RestSource/Helpers/RestSourceTriggerFunctionsTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackageManifests_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             var apiResponse = new ApiResponse<PackageManifest>(new PackageManifest());
@@ -80,6 +80,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var result = await restSourceTriggerFunctions.GetPackageManifestAsync(
                 httpClient,
                 packageIdentifier,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -98,7 +99,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackageManifests_NoContentTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
@@ -125,6 +126,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var result = await restSourceTriggerFunctions.GetPackageManifestAsync(
                 httpClient,
                 packageIdentifier,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -138,7 +140,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackageManifests_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
@@ -165,6 +167,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 async () => await restSourceTriggerFunctions.GetPackageManifestAsync(
                     httpClient,
                     packageIdentifier,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -177,7 +180,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task PostPackageManifestAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             var packageManifest = new PackageManifest();
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests");
@@ -203,6 +206,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             await restSourceTriggerFunctions.PostPackageManifestAsync(
                 httpClient,
                 packageManifest,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -215,7 +219,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task PostPackageManifestAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             var packageManifest = new PackageManifest();
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests");
@@ -242,6 +246,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 async () => await restSourceTriggerFunctions.PostPackageManifestAsync(
                     httpClient,
                     packageManifest,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -254,7 +259,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task PutPackageManifestAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             var packageManifest = new PackageManifest();
             packageManifest.PackageIdentifier = "packageIdentifier";
@@ -281,6 +286,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             await restSourceTriggerFunctions.PutPackageManifestAsync(
                 httpClient,
                 packageManifest,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -293,7 +299,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task PutPackageManifestAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             var packageManifest = new PackageManifest();
             packageManifest.PackageIdentifier = "packageIdentifier";
@@ -321,6 +327,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 async () => await restSourceTriggerFunctions.PutPackageManifestAsync(
                     httpClient,
                     packageManifest,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -333,7 +340,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeletePackageManifestAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
@@ -359,6 +366,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             await restSourceTriggerFunctions.DeletePackageManifestAsync(
                 httpClient,
                 packageIdentifier,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -371,7 +379,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeletePackageManifestAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
@@ -398,6 +406,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 async () => await restSourceTriggerFunctions.DeletePackageManifestAsync(
                     httpClient,
                     packageIdentifier,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -410,7 +419,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetAllPackagesAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages");
 
@@ -472,6 +481,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             var result = await restSourceTriggerFunctions.GetAllPackagesAsync(
                 httpClient,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -485,7 +495,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackagesAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages");
 
@@ -517,6 +527,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             var result = await restSourceTriggerFunctions.GetPackagesAsync(
                 httpClient,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -530,7 +541,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackagesAsync_NoContentTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages");
 
@@ -554,6 +565,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             var result = await restSourceTriggerFunctions.GetPackagesAsync(
                 httpClient,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -567,7 +579,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task GetPackagesAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages");
 
@@ -592,6 +604,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             await Assert.ThrowsAsync<RestSourceCallException>(
                 async () => await restSourceTriggerFunctions.GetPackagesAsync(
                     httpClient,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -604,7 +617,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeletePackageAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}");
@@ -630,6 +643,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             await restSourceTriggerFunctions.DeletePackageAsync(
                 httpClient,
                 packageIdentifier,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -642,7 +656,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeletePackageAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}");
@@ -669,6 +683,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 async () => await restSourceTriggerFunctions.DeletePackageAsync(
                     httpClient,
                     packageIdentifier,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();
@@ -681,7 +696,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeleteVersionAsync_Test()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             string version = "version";
@@ -709,6 +724,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                 httpClient,
                 packageIdentifier,
                 version,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();
@@ -721,7 +737,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
         [Fact]
         public async Task DeleteVersionAsync_FailureStatusCodeTest()
         {
-            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
+            var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint);
 
             string packageIdentifier = "packageIdentifier";
             string version = "version";
@@ -750,6 +766,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
                     httpClient,
                     packageIdentifier,
                     version,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockHttpMessageHandler.Verify();

--- a/src/WinGet.RestSource.UnitTest/Tests/RestSource/Operation/RebuildTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/RestSource/Operation/RebuildTests.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
     public class RebuildTests
     {
         private const string AzFuncRestSourceEndpoint = "https://fakestorage.blob.core.windows.net/cache/";
+        private const string AzFuncHostKey = "1234567890";
 
         private readonly ITestOutputHelper log;
         private readonly LoggingContext loggingContext;
@@ -130,6 +131,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.PostPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     It.Is<PackageManifest>(p => p.PackageIdentifier == rtestPackage.Id),
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -138,6 +140,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.PutPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     It.Is<PackageManifest>(p => p.PackageIdentifier == atestPackage.Id),
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -146,6 +149,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.DeletePackageAsync(
                     It.IsAny<HttpClient>(),
                     etestPackageId,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -159,6 +163,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 inputRestPackages,
                 mockRestSourceTriggerFunction.Object,
                 AzFuncRestSourceEndpoint,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockHttpMessageHandler.Verify();

--- a/src/WinGet.RestSource.UnitTest/Tests/RestSource/Operation/UpdateTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/RestSource/Operation/UpdateTests.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
     /// </summary>
     public class UpdateTests
     {
+        private const string AzFuncHostKey = "1234567890";
+
         private readonly ITestOutputHelper log;
         private readonly LoggingContext loggingContext;
 
@@ -59,6 +61,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -67,6 +70,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.PostPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     It.Is<PackageManifest>(p => p.PackageIdentifier == inputManifest.Id),
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -74,6 +78,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 mockHttpClient.Object,
                 inputManifest,
                 mockRestSourceTriggerFunction.Object,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockRestSourceTriggerFunction.Verify();
@@ -101,6 +106,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -109,6 +115,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.PutPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     It.Is<PackageManifest>(p => p.PackageIdentifier == inputManifest.Id && p.Versions.VersionExists(inputManifest.Version)),
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -116,6 +123,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 mockHttpClient.Object,
                 inputManifest,
                 mockRestSourceTriggerFunction.Object,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockRestSourceTriggerFunction.Verify();
@@ -140,6 +148,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -149,6 +158,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     mockHttpClient.Object,
                     inputManifest,
                     mockRestSourceTriggerFunction.Object,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockRestSourceTriggerFunction.Verify();
@@ -173,6 +183,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -181,6 +192,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.PutPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     It.Is<PackageManifest>(p => p.PackageIdentifier == inputManifest.Id),
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -188,6 +200,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 mockHttpClient.Object,
                 inputManifest,
                 mockRestSourceTriggerFunction.Object,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockRestSourceTriggerFunction.Verify();
@@ -212,6 +225,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -221,6 +235,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     mockHttpClient.Object,
                     inputManifest,
                     mockRestSourceTriggerFunction.Object,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockRestSourceTriggerFunction.Verify();
@@ -247,6 +262,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -256,6 +272,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     mockHttpClient.Object,
                     inputManifest,
                     mockRestSourceTriggerFunction.Object,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockRestSourceTriggerFunction.Verify();
@@ -280,6 +297,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -288,6 +306,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.DeletePackageAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -295,6 +314,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 mockHttpClient.Object,
                 inputManifest,
                 mockRestSourceTriggerFunction.Object,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockRestSourceTriggerFunction.Verify();
@@ -324,6 +344,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -333,6 +354,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
                     inputManifest.Version,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .Verifiable();
 
@@ -340,6 +362,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 mockHttpClient.Object,
                 inputManifest,
                 mockRestSourceTriggerFunction.Object,
+                AzFuncHostKey,
                 this.loggingContext);
 
             mockRestSourceTriggerFunction.Verify();
@@ -366,6 +389,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -375,6 +399,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     mockHttpClient.Object,
                     inputManifest,
                     mockRestSourceTriggerFunction.Object,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockRestSourceTriggerFunction.Verify();
@@ -399,6 +424,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                 m => m.GetPackageManifestAsync(
                     It.IsAny<HttpClient>(),
                     inputManifest.Id,
+                    AzFuncHostKey,
                     It.IsAny<LoggingContext>()))
                 .ReturnsAsync(packageManifest)
                 .Verifiable();
@@ -408,6 +434,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Operation
                     mockHttpClient.Object,
                     inputManifest,
                     mockRestSourceTriggerFunction.Object,
+                    AzFuncHostKey,
                     this.loggingContext));
 
             mockRestSourceTriggerFunction.Verify();

--- a/src/WinGet.RestSource/Helpers/RestSourceTriggerFunctions.cs
+++ b/src/WinGet.RestSource/Helpers/RestSourceTriggerFunctions.cs
@@ -41,16 +41,13 @@ namespace Microsoft.WinGet.RestSource.Helpers
 
         private readonly string azFuncVersionsEndpointFormat;
         private readonly string azFuncVersionsSpecificEndpointFormat;
-        private readonly string azFuncHostKey;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestSourceTriggerFunctions"/> class.
         /// </summary>
         /// <param name="azFuncRestSourceEndpoint">Azure function Rest Source Endpoint.</param>
-        /// <param name="azFuncHostKey">Azure function host key.</param>
         public RestSourceTriggerFunctions(
-            string azFuncRestSourceEndpoint,
-            string azFuncHostKey)
+            string azFuncRestSourceEndpoint)
         {
             this.azFuncPackageManifestsEndpoint = $"{azFuncRestSourceEndpoint}{PackageManifests}";
             this.azFuncPackageManifestsEndpointFormat = this.azFuncPackageManifestsEndpoint + "/{0}";
@@ -60,14 +57,13 @@ namespace Microsoft.WinGet.RestSource.Helpers
 
             this.azFuncVersionsEndpointFormat = this.azFuncPackagesEndpointFormat + $"/{Versions}";
             this.azFuncVersionsSpecificEndpointFormat = this.azFuncVersionsEndpointFormat + "/{1}";
-
-            this.azFuncHostKey = azFuncHostKey;
         }
 
         /// <inheritdoc />
         public async Task<PackageManifest> GetPackageManifestAsync(
             HttpClient httpClient,
             string packageIndetifier,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext} Start Get PackageManifest {packageIndetifier}");
@@ -78,7 +74,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey);
+                azFuncHostKey);
 
             Logger.Info($"{loggingContext} Get PackageManifest {packageIndetifier} response StatusCode '{responseMessage.StatusCode}'");
 
@@ -100,6 +96,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         public async Task PostPackageManifestAsync(
             HttpClient httpClient,
             PackageManifest packageManifest,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             string requestBody = JsonConvert.SerializeObject(packageManifest);
@@ -111,7 +108,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 this.azFuncPackageManifestsEndpoint,
-                this.azFuncHostKey,
+                azFuncHostKey,
                 requestBody);
 
             Logger.Info($"{loggingContext} Post PackageManifest response {packageManifest.PackageIdentifier} StatusCode '{responseMessage.StatusCode}'");
@@ -126,6 +123,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         public async Task PutPackageManifestAsync(
             HttpClient httpClient,
             PackageManifest packageManifest,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             string requestBody = JsonConvert.SerializeObject(packageManifest);
@@ -137,7 +135,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey,
+                azFuncHostKey,
                 requestBody);
 
             Logger.Info($"{loggingContext} Put PackageManifest {packageManifest.PackageIdentifier} response StatusCode '{responseMessage.StatusCode}'");
@@ -152,6 +150,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         public async Task DeletePackageManifestAsync(
             HttpClient httpClient,
             string packageIdentifier,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext} Start Delete PackageManifest {packageIdentifier}");
@@ -162,7 +161,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey);
+                azFuncHostKey);
 
             Logger.Info($"{loggingContext} Delete PackageManifest {packageIdentifier} response StatusCode '{responseMessage.StatusCode}'");
 
@@ -175,6 +174,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         /// <inheritdoc />
         public async Task<IReadOnlyList<Package>> GetAllPackagesAsync(
             HttpClient httpClient,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext} Start Get All Packages");
@@ -186,6 +186,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
             {
                 var pagedPackages = await this.GetPackagesAsync(
                     httpClient,
+                    azFuncHostKey,
                     loggingContext,
                     continuationToken);
 
@@ -206,6 +207,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         /// <inheritdoc />
         public async Task<ApiResponse<List<Package>>> GetPackagesAsync(
             HttpClient httpClient,
+            string azFuncHostKey,
             LoggingContext loggingContext,
             string continuationToken = null)
         {
@@ -226,7 +228,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey,
+                azFuncHostKey,
                 headers: headers);
 
             Logger.Info($"{loggingContext} Get Package response ContinuationToken {continuationToken} StatusCode '{responseMessage.StatusCode}'");
@@ -249,6 +251,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
         public async Task DeletePackageAsync(
             HttpClient httpClient,
             string packageIdentifier,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext} Start Delete Package {packageIdentifier}");
@@ -259,7 +262,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey);
+                azFuncHostKey);
 
             Logger.Info($"{loggingContext} Delete Package {packageIdentifier} response StatusCode '{responseMessage.StatusCode}'");
 
@@ -274,6 +277,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
             HttpClient httpClient,
             string packageIdentifier,
             string version,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext} Start Delete Version {packageIdentifier} {version}");
@@ -284,7 +288,7 @@ namespace Microsoft.WinGet.RestSource.Helpers
                 httpClient,
                 httpMethod,
                 endpoint,
-                this.azFuncHostKey);
+                azFuncHostKey);
 
             Logger.Info($"{loggingContext} Delete Version response {packageIdentifier} {version} response StatusCode '{responseMessage.StatusCode}'");
 

--- a/src/WinGet.RestSource/Interfaces/IRebuild.cs
+++ b/src/WinGet.RestSource/Interfaces/IRebuild.cs
@@ -25,6 +25,7 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// <param name="type">type of operation performed on the SQLite file.</param>
         /// <param name="restSourceTriggerFunction">IRestSourceTriggerFunction.</param>
         /// <param name="manifestCacheEndpoint">Manifest cache endpoint.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task ProcessRebuildRequestAsync(
@@ -34,6 +35,7 @@ namespace Microsoft.WinGet.RestSource.Interfaces
             ReferenceType type,
             IRestSourceTriggerFunction restSourceTriggerFunction,
             string manifestCacheEndpoint,
+            string azFuncHostKey,
             LoggingContext loggingContext);
     }
 }

--- a/src/WinGet.RestSource/Interfaces/IRestSourceTriggerFunction.cs
+++ b/src/WinGet.RestSource/Interfaces/IRestSourceTriggerFunction.cs
@@ -23,11 +23,13 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// </summary>
         /// <param name="httpClient">Http Client.</param>
         /// <param name="packageIndetifier">Package indetifier.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task<PackageManifest> GetPackageManifestAsync(
             HttpClient httpClient,
             string packageIndetifier,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
@@ -35,11 +37,13 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="packageManifest">Package Manifest.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task PostPackageManifestAsync(
             HttpClient httpClient,
             PackageManifest packageManifest,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
@@ -47,11 +51,13 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="packageManifest">Package Manifest.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task PutPackageManifestAsync(
             HttpClient httpClient,
             PackageManifest packageManifest,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
@@ -59,32 +65,38 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="packageIdentifier">Package Identifier.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task DeletePackageManifestAsync(
             HttpClient httpClient,
             string packageIdentifier,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
         /// Get all packages.
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>List of packages.</returns>
         Task<IReadOnlyList<Package>> GetAllPackagesAsync(
             HttpClient httpClient,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
         /// Gets paged packages.
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">LoggingContext.</param>
         /// <param name="continuationToken">Optional continuation token.</param>
         /// <returns>List of packages.</returns>
         Task<ApiResponse<List<Package>>> GetPackagesAsync(
             HttpClient httpClient,
+            string azFuncHostKey,
             LoggingContext loggingContext,
             string continuationToken = null);
 
@@ -93,11 +105,13 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// </summary>
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="packageIdentifier">Package indentifier.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task DeletePackageAsync(
             HttpClient httpClient,
             string packageIdentifier,
+            string azFuncHostKey,
             LoggingContext loggingContext);
 
         /// <summary>
@@ -106,12 +120,14 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="packageIdentifier">Package identifier.</param>
         /// <param name="version">Version.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">LoggingContext.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task DeleteVersionAsync(
             HttpClient httpClient,
             string packageIdentifier,
             string version,
+            string azFuncHostKey,
             LoggingContext loggingContext);
     }
 }

--- a/src/WinGet.RestSource/Interfaces/IUpdate.cs
+++ b/src/WinGet.RestSource/Interfaces/IUpdate.cs
@@ -25,6 +25,7 @@ namespace Microsoft.WinGet.RestSource.Interfaces
         /// <param name="sasManifestUrl">SAS manifest url.</param>
         /// <param name="referenceType">Reference type.</param>
         /// <param name="restSourceTriggerFunction">RestSourceTriggerFunction.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task ProcessUpdateRequestAsync(
@@ -34,6 +35,7 @@ namespace Microsoft.WinGet.RestSource.Interfaces
             string sasManifestUrl,
             ReferenceType referenceType,
             IRestSourceTriggerFunction restSourceTriggerFunction,
+            string azFuncHostKey,
             LoggingContext loggingContext);
     }
 }

--- a/src/WinGet.RestSource/Operations/Update.cs
+++ b/src/WinGet.RestSource/Operations/Update.cs
@@ -40,6 +40,7 @@ namespace Microsoft.WinGet.RestSource.Operations
             string sasManifestUrl,
             ReferenceType referenceType,
             IRestSourceTriggerFunction restSourceTriggerFunction,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             Logger.Info($"{loggingContext}Processing commit {commit} from {operationId} for type {referenceType}");
@@ -57,6 +58,7 @@ namespace Microsoft.WinGet.RestSource.Operations
                     httpClient,
                     manifest,
                     restSourceTriggerFunction,
+                    azFuncHostKey,
                     loggingContext);
             }
             else if (referenceType == ReferenceType.Modify)
@@ -65,6 +67,7 @@ namespace Microsoft.WinGet.RestSource.Operations
                     httpClient,
                     manifest,
                     restSourceTriggerFunction,
+                    azFuncHostKey,
                     loggingContext);
             }
             else if (referenceType == ReferenceType.Delete)
@@ -73,6 +76,7 @@ namespace Microsoft.WinGet.RestSource.Operations
                     httpClient,
                     manifest,
                     restSourceTriggerFunction,
+                    azFuncHostKey,
                     loggingContext);
             }
             else
@@ -87,16 +91,22 @@ namespace Microsoft.WinGet.RestSource.Operations
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="manifest">Manifest.</param>
         /// <param name="restSourceTriggerFunction">Rest source trigger.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         internal async Task ProcessManifestAddAsync(
             HttpClient httpClient,
             Manifest manifest,
             IRestSourceTriggerFunction restSourceTriggerFunction,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             // Check if the package already exists.
-            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(httpClient, manifest.Id, loggingContext);
+            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(
+                httpClient,
+                manifest.Id,
+                azFuncHostKey,
+                loggingContext);
             if (packageManifest == null)
             {
                 Logger.Info($"{loggingContext}Package {manifest.Id} doesn't exists");
@@ -104,7 +114,11 @@ namespace Microsoft.WinGet.RestSource.Operations
                 await RetryHelper.RunAndRetryWithExceptionAsync<HttpRequestException>(
                     async () =>
                     {
-                        await restSourceTriggerFunction.PostPackageManifestAsync(httpClient, packageManifest, loggingContext);
+                        await restSourceTriggerFunction.PostPackageManifestAsync(
+                            httpClient,
+                            packageManifest,
+                            azFuncHostKey,
+                            loggingContext);
                     },
                     manifest.Id,
                     loggingContext,
@@ -125,7 +139,11 @@ namespace Microsoft.WinGet.RestSource.Operations
                 await RetryHelper.RunAndRetryWithExceptionAsync<HttpRequestException>(
                     async () =>
                     {
-                        await restSourceTriggerFunction.PutPackageManifestAsync(httpClient, packageManifest, loggingContext);
+                        await restSourceTriggerFunction.PutPackageManifestAsync(
+                            httpClient,
+                            packageManifest,
+                            azFuncHostKey,
+                            loggingContext);
                     },
                     manifest.Id,
                     loggingContext,
@@ -139,16 +157,22 @@ namespace Microsoft.WinGet.RestSource.Operations
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="manifest">Manifest.</param>
         /// <param name="restSourceTriggerFunction">Rest source trigger.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         internal async Task ProcessManifestModifyAsync(
             HttpClient httpClient,
             Manifest manifest,
             IRestSourceTriggerFunction restSourceTriggerFunction,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             // If this is a modify then it must be already be there.
-            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(httpClient, manifest.Id, loggingContext);
+            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(
+                httpClient,
+                manifest.Id,
+                azFuncHostKey,
+                loggingContext);
             if (packageManifest == null)
             {
                 throw new InvalidOperationException($"Package {manifest.Id} does not exists.");
@@ -166,7 +190,11 @@ namespace Microsoft.WinGet.RestSource.Operations
             await RetryHelper.RunAndRetryWithExceptionAsync<HttpRequestException>(
                 async () =>
                 {
-                    await restSourceTriggerFunction.PutPackageManifestAsync(httpClient, packageManifest, loggingContext);
+                    await restSourceTriggerFunction.PutPackageManifestAsync(
+                        httpClient,
+                        packageManifest,
+                        azFuncHostKey,
+                        loggingContext);
                 },
                 manifest.Id,
                 loggingContext,
@@ -179,16 +207,22 @@ namespace Microsoft.WinGet.RestSource.Operations
         /// <param name="httpClient">HttpClient.</param>
         /// <param name="manifest">Manifest.</param>
         /// <param name="restSourceTriggerFunction">Rest source trigger.</param>
+        /// <param name="azFuncHostKey">Azure function host key.</param>
         /// <param name="loggingContext">Logging context.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         internal async Task ProcessManifestDeleteAsync(
             HttpClient httpClient,
             Manifest manifest,
             IRestSourceTriggerFunction restSourceTriggerFunction,
+            string azFuncHostKey,
             LoggingContext loggingContext)
         {
             // If this is a delete then it must be already be there.
-            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(httpClient, manifest.Id, loggingContext);
+            var packageManifest = await restSourceTriggerFunction.GetPackageManifestAsync(
+                httpClient,
+                manifest.Id,
+                azFuncHostKey,
+                loggingContext);
             if (packageManifest == null)
             {
                 throw new InvalidOperationException($"Package {manifest.Id} does not exists.");
@@ -205,7 +239,12 @@ namespace Microsoft.WinGet.RestSource.Operations
                 await RetryHelper.RunAndRetryWithExceptionAsync<HttpRequestException>(
                     async () =>
                     {
-                        await restSourceTriggerFunction.DeleteVersionAsync(httpClient, manifest.Id, manifest.Version, loggingContext);
+                        await restSourceTriggerFunction.DeleteVersionAsync(
+                            httpClient,
+                            manifest.Id,
+                            manifest.Version,
+                            azFuncHostKey,
+                            loggingContext);
                     },
                     manifest.Id,
                     loggingContext,
@@ -216,7 +255,11 @@ namespace Microsoft.WinGet.RestSource.Operations
                 await RetryHelper.RunAndRetryWithExceptionAsync<HttpRequestException>(
                     async () =>
                     {
-                        await restSourceTriggerFunction.DeletePackageAsync(httpClient, manifest.Id, loggingContext);
+                        await restSourceTriggerFunction.DeletePackageAsync(
+                            httpClient,
+                            manifest.Id,
+                            azFuncHostKey,
+                            loggingContext);
                     },
                     manifest.Id,
                     loggingContext,


### PR DESCRIPTION
Before we read the environment variable for the azure function host key in the startup of the function app. If the key gets rotated, the new value won't get refreshed until a new deployment is made.

Fix is to read the env var when is needed.