### PR TITLE
Add / at the end for internal REST endpoint calls

### DIFF
--- a/src/WinGet.RestSource.UnitTest/Tests/RestSource/Helpers/RestSourceTriggerFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/RestSource/Helpers/RestSourceTriggerFunctionsTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RestSourceTriggerFunctionsTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -56,7 +56,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             string packageIdentifier = "packageIdentifier";
             var apiResponse = new ApiResponse<PackageManifest>(new PackageManifest());
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -101,7 +101,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -141,7 +141,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -258,7 +258,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             var packageManifest = new PackageManifest();
             packageManifest.PackageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageManifest.PackageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageManifest.PackageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -297,7 +297,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
 
             var packageManifest = new PackageManifest();
             packageManifest.PackageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageManifest.PackageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageManifest.PackageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -336,7 +336,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -374,7 +374,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packageManifests/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -607,7 +607,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler
@@ -645,7 +645,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.RestSource.Helpers
             var restSourceTriggerFunctions = new RestSourceTriggerFunctions(AzFuncRestSourceEndpoint, AzFuncHostKey);
 
             string packageIdentifier = "packageIdentifier";
-            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}");
+            Uri expectedUri = new Uri($"{AzFuncRestSourceEndpoint}packages/{packageIdentifier}/");
 
             var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
             mockHttpMessageHandler

--- a/src/WinGet.RestSource/Helpers/RestSourceTriggerFunctions.cs
+++ b/src/WinGet.RestSource/Helpers/RestSourceTriggerFunctions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="RestSourceTriggerFunctions.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -53,12 +53,12 @@ namespace Microsoft.WinGet.RestSource.Helpers
             string azFuncHostKey)
         {
             this.azFuncPackageManifestsEndpoint = $"{azFuncRestSourceEndpoint}{PackageManifests}";
-            this.azFuncPackageManifestsEndpointFormat = this.azFuncPackageManifestsEndpoint + "/{0}";
+            this.azFuncPackageManifestsEndpointFormat = this.azFuncPackageManifestsEndpoint + "/{0}/";
 
             this.azFuncPackagesEndpoint = $"{azFuncRestSourceEndpoint}{Packages}";
-            this.azFuncPackagesEndpointFormat = this.azFuncPackagesEndpoint + "/{0}";
+            this.azFuncPackagesEndpointFormat = this.azFuncPackagesEndpoint + "/{0}/";
 
-            this.azFuncVersionsEndpointFormat = this.azFuncPackagesEndpointFormat + $"/{Versions}";
+            this.azFuncVersionsEndpointFormat = this.azFuncPackagesEndpointFormat + $"{Versions}";
             this.azFuncVersionsSpecificEndpointFormat = this.azFuncVersionsEndpointFormat + "/{1}";
 
             this.azFuncHostKey = azFuncHostKey;


### PR DESCRIPTION
Doing operations on packages that end with .browser will result in a 404.

Adding a / at the end fix it. 

We will look in the future on a better fix.