### PR TITLE
Correct Typo in Azure Function Template

### DIFF
--- a/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
+++ b/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
@@ -195,7 +195,7 @@
     "variables": {
         "appInsightResourceId": "[resourceId(parameters('appInsightSubscription'), parameters('appInsightResourceGroup'), 'microsoft.insights/components', parameters('appInsightName'))]",
         "appServiceResourceId": "[resourceId(parameters('appServiceSubscription'), parameters('appServiceResourceGroup'), 'Microsoft.Web/serverfarms/', parameters('appServiceName'))]",
-        "certificateAuthenticationEnabled": "[if(parameters('clientCertEnabled'), 'true', 'flase' )]",
+        "certificateAuthenticationEnabled": "[if(parameters('clientCertEnabled'), 'true', 'false' )]",
         "kv_appConfigPrimary_SecretName": "AppConfigPrimary",
         "kv_appConfigSecondary_SecretName": "AppConfigSecondary",
         "kv_cosmosAccountEndpoint_secretName": "CosmosAccountEndpoint",


### PR DESCRIPTION
This corrects a typo that causes all calls to fail with a 500 error for improper parsing.