### PR TITLE
Update protocol max items to 64

### DIFF
--- a/documentation/WinGet-1.4.0.yaml
+++ b/documentation/WinGet-1.4.0.yaml
@@ -994,7 +994,7 @@ components:
       type: array
       nullable: true
       uniqueItems: true
-      maxItems: 16
+      maxItems: 64
       items:
         type: string
         maxLength: 2048

--- a/src/WinGet.RestSource.Utils/Models/Arrays/Protocols.cs
+++ b/src/WinGet.RestSource.Utils/Models/Arrays/Protocols.cs
@@ -17,7 +17,7 @@ namespace Microsoft.WinGet.RestSource.Utils.Models.Arrays
     {
         private const bool Nullable = true;
         private const bool Unique = true;
-        private const uint Max = 16;
+        private const uint Max = 64;
         private static readonly Type Validator = typeof(ProtocolsValidator);
 
         /// <summary>


### PR DESCRIPTION
Related to: https://github.com/microsoft/winget-cli/issues/2600

Updates the max number of items for the Protocols field from 16 to 64.