### PR TITLE
Fix Locale API url path are incorrect at API Documentation

### DIFF
--- a/documentation/WinGet-1.0.0.yaml
+++ b/documentation/WinGet-1.0.0.yaml
@@ -213,7 +213,7 @@ paths:
           $ref: '#/components/responses/GenericError'
 
   # Locale API Calls
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/PackageIdentifier'
@@ -256,7 +256,7 @@ paths:
         default:
           $ref: '#/components/responses/GenericError'
 
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale/{PackageLocale}:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales/{PackageLocale}:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/PackageIdentifier'

--- a/documentation/WinGet-1.1.0.yaml
+++ b/documentation/WinGet-1.1.0.yaml
@@ -217,7 +217,7 @@ paths:
           $ref: '#/components/responses/GenericError'
 
   # Locale API Calls
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/Windows-Package-Manager'
@@ -261,7 +261,7 @@ paths:
         default:
           $ref: '#/components/responses/GenericError'
 
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale/{PackageLocale}:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales/{PackageLocale}:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/Windows-Package-Manager'

--- a/documentation/WinGet-1.4.0.yaml
+++ b/documentation/WinGet-1.4.0.yaml
@@ -217,7 +217,7 @@ paths:
           $ref: '#/components/responses/GenericError'
 
   # Locale API Calls
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/Windows-Package-Manager'
@@ -261,7 +261,7 @@ paths:
         default:
           $ref: '#/components/responses/GenericError'
 
-  /packages/{PackageIdentifier}/versions/{PackageVersion}/locale/{PackageLocale}:
+  /packages/{PackageIdentifier}/versions/{PackageVersion}/locales/{PackageLocale}:
     parameters:
       - $ref: '#/components/parameters/APIVersion'
       - $ref: '#/components/parameters/Windows-Package-Manager'


### PR DESCRIPTION
Hi Microsoft,

Look like  `Locale` API URL path are incorrect at API Documentation

`/packages/{PackageIdentifier}/versions/{PackageVersion}/locale`
`/packages/{PackageIdentifier}/versions/{PackageVersion}/locale/{PackageLocale}`

should be 
`/packages/{PackageIdentifier}/versions/{PackageVersion}/locales`
`/packages/{PackageIdentifier}/versions/{PackageVersion}/locales/{PackageLocale}`

missing `s`

Thanks.