### PR TITLE
Porting to .NET 6 and Azure Functions Runtime 4

### DIFF
--- a/Tools/PowershellModule/src/Library/New-WinGetSource.ps1
+++ b/Tools/PowershellModule/src/Library/New-WinGetSource.ps1
@@ -128,6 +128,11 @@ Function New-WinGetSource
         #### Verifies ARM Parameters are correct ####
         $Result = Test-ARMTemplate -ARMObjects $ARMObjects -ResourceGroup $ResourceGroup -ErrorAction SilentlyContinue -ErrorVariable err
 
+        Write-Output $Result
+        Write-Output "---ERROR---"
+        Write-Output $err
+        Write-Output "-----------"
+
         if($err){
             $ErrReturnObject = @{
                 ARMObjects    = $ARMObjects

--- a/Tools/PowershellModule/src/Library/New-WinGetSource.ps1
+++ b/Tools/PowershellModule/src/Library/New-WinGetSource.ps1
@@ -128,11 +128,6 @@ Function New-WinGetSource
         #### Verifies ARM Parameters are correct ####
         $Result = Test-ARMTemplate -ARMObjects $ARMObjects -ResourceGroup $ResourceGroup -ErrorAction SilentlyContinue -ErrorVariable err
 
-        Write-Output $Result
-        Write-Output "---ERROR---"
-        Write-Output $err
-        Write-Output "-----------"
-
         if($err){
             $ErrReturnObject = @{
                 ARMObjects    = $ARMObjects

--- a/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
+++ b/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
+++ b/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <Company>Microsoft</Company>
         <Authors>Microsoft</Authors>
         <AssemblyName>Microsoft.WinGet.RestSource.AppConfig</AssemblyName>

--- a/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
+++ b/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AzureFunctionsVersion>V3</AzureFunctionsVersion>
+    <TargetFramework>net6.0</TargetFramework>
+    <AzureFunctionsVersion>V4</AzureFunctionsVersion>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <Platforms>AnyCPU</Platforms>

--- a/src/WinGet.RestSource.IntegrationTest/WinGet.RestSource.IntegrationTest.csproj
+++ b/src/WinGet.RestSource.IntegrationTest/WinGet.RestSource.IntegrationTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <AssemblyName>Microsoft.WinGet.RestSource.IntegrationTest</AssemblyName>

--- a/src/WinGet.RestSource.PowershellSupport/WinGet.RestSource.PowershellSupport.csproj
+++ b/src/WinGet.RestSource.PowershellSupport/WinGet.RestSource.PowershellSupport.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>

--- a/src/WinGet.RestSource.UnitTest/Common/TestCollateralHelper.cs
+++ b/src/WinGet.RestSource.UnitTest/Common/TestCollateralHelper.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="TestCollateralHelper.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -48,8 +48,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Common
         /// <returns>Test collateral path.</returns>
         public static string GetTestCollateralPath(TestCollateral testCollateral)
         {
-            Uri codeBaseUrl = new Uri(Assembly.GetExecutingAssembly().CodeBase);
-            string codeBasePath = Uri.UnescapeDataString(codeBaseUrl.AbsolutePath);
+            string codeBasePath = Assembly.GetExecutingAssembly().Location;
             return Path.Combine(
                 Path.GetDirectoryName(codeBasePath),
                 "TestCollateral",

--- a/src/WinGet.RestSource.UnitTest/WinGet.RestSource.UnitTest.csproj
+++ b/src/WinGet.RestSource.UnitTest/WinGet.RestSource.UnitTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <AssemblyName>Microsoft.Winget.RestSource.UnitTest</AssemblyName>

--- a/src/WinGet.RestSource.Utils/WinGet.RestSource.Utils.csproj
+++ b/src/WinGet.RestSource.Utils/WinGet.RestSource.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <AssemblyName>Microsoft.WinGet.RestSource.Utils</AssemblyName>

--- a/src/WinGet.RestSource/WinGet.RestSource.csproj
+++ b/src/WinGet.RestSource/WinGet.RestSource.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Company>Microsoft</Company>
     <Authors>Microsoft</Authors>
     <AssemblyName>Microsoft.WinGet.RestSource</AssemblyName>


### PR DESCRIPTION
* Azure Function project (and all its dependencies) migrated to .NET 6 and Functions Runtime 4. 