### PR TITLE
Fix pipeline build break

### DIFF
--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -23,7 +23,6 @@ steps:
     solution: '**\*.sln'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
-    vsVersion: 17.0
     clean: true
 
 ## Publish

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -20,6 +20,7 @@ steps:
 - task: VSBuild@1
   displayName: Build
   inputs:
+    solution: '**\*.sln'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
     clean: true
@@ -60,7 +61,7 @@ steps:
 - template: run-unittests.yml
   parameters:
     name: WinGet.RestSource.UnitTest
-    testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\netcoreapp3.1'
+    testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\net6.0'
     dll: Microsoft.WinGet.RestSource.UnitTest.
 
 ## Component Governance

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -23,6 +23,7 @@ steps:
     solution: '**\*.sln'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
+    vsVersion: 17.0
     clean: true
 
 ## Publish

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -14,6 +14,10 @@ pr:
     - pipelines/*
     - src/*
 
+variables:
+- name: DisablePipelineConfigDetector
+  value: true
+
 jobs:
 - job: 'BuildPublishTest'
   displayName: 'Build Publish & Tests'

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -36,7 +36,7 @@ jobs:
   displayName: 'Static Analysis'
   timeoutInMinutes: 60
   pool:
-    vmImage: windows-2019
+    vmImage: windows-latest
     demands:
     - msbuild
     - visualstudio

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -26,6 +26,7 @@ jobs:
   displayName: 'Build Publish & Tests'
   timeoutInMinutes: 60
   pool:
+    name: 'Azure Pipelines'
     vmImage: windows-latest
     demands:
     - msbuild

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -44,6 +44,7 @@ jobs:
   displayName: 'Static Analysis'
   timeoutInMinutes: 60
   pool:
+    name: 'Azure Pipelines'
     vmImage: windows-latest
     demands:
     - msbuild

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -14,6 +14,9 @@ pr:
     - pipelines/*
     - src/*
 
+# TODO: The forked pr builds need to have the same permission as non-forked ones to access
+#       project's internal nuget feed. Remove DisablePipelineConfigDetector variable when
+#       a long term fix is available.
 variables:
 - name: DisablePipelineConfigDetector
   value: true

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -46,6 +46,7 @@ jobs:
   displayName: 'Static Analysis'
   timeoutInMinutes: 120
   pool:
+    name: 'Azure Pipelines'
     vmImage: windows-latest
     demands:
     - msbuild
@@ -72,8 +73,8 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-semmle.Semmle@0
     displayName: 'Run Semmle'
     inputs:
-      cleanupBuildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
-      buildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
+      cleanupBuildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
+      buildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
 
   # Publish SDT Logs
   - template: templates/copy-and-publish.yml

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -45,7 +45,7 @@ jobs:
   displayName: 'Static Analysis'
   timeoutInMinutes: 120
   pool:
-    vmImage: windows-2019
+    vmImage: windows-latest
     demands:
     - msbuild
     - visualstudio

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -10,6 +10,7 @@ jobs:
   displayName: 'Build Test & Publish'
   timeoutInMinutes: 60
   pool:
+    name: 'Azure Pipelines'
     vmImage: windows-latest
     demands:
     - msbuild

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -73,8 +73,8 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-semmle.Semmle@0
     displayName: 'Run Semmle'
     inputs:
-      cleanupBuildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
-      buildCommands: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
+      cleanupBuildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
+      buildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
 
   # Publish SDT Logs
   - template: templates/copy-and-publish.yml

--- a/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
+++ b/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Msix.Utils" Version="*" />
     <PackageReference Include="Microsoft.Cloud.InstrumentationFramework.NetStd" Version="1.2.1011530001" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.11" />
-    <PackageReference Include="Bond.CSharp" Version="9.0.3" />
+    <PackageReference Include="Bond.CSharp" Version="10.0.0" />
   </ItemGroup>
 
   <!-- Component Governance fix Item Group. -->

--- a/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
+++ b/src/Microsoft.WindowsPackageManager.Rest/Microsoft.WindowsPackageManager.Rest.csproj
@@ -47,7 +47,7 @@
     <PackageReference Include="Microsoft.Msix.Utils" Version="*" />
     <PackageReference Include="Microsoft.Cloud.InstrumentationFramework.NetStd" Version="1.2.1011530001" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.11" />
-    <PackageReference Include="Bond.CSharp" Version="10.0.0" />
+    <PackageReference Include="Bond.CSharp" Version="11.0.0" />
   </ItemGroup>
 
   <!-- Component Governance fix Item Group. -->

--- a/src/WinGet.RestSource.sln
+++ b/src/WinGet.RestSource.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.32428.217
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33627.172
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource", "WinGet.RestSource\WinGet.RestSource.csproj", "{15E4BE9B-2891-410A-A042-47FE838B1AEC}"
 EndProject
@@ -8,10 +8,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource.Functions
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{145CC9B9-A93E-46C1-90F7-DFB81233B39F}"
 	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
 		..\.gitignore = ..\.gitignore
 		NuGet.config = NuGet.config
 		stylecop.json = stylecop.json
-		..\.editorconfig = ..\.editorconfig
 	EndProjectSection
 EndProject
 Project("{151D2E53-A2C4-4D7D-83FE-D05416EBD58E}") = "WinGet.RestSource.Infrastructure", "WinGet.RestSource.Infrastructure\WinGet.RestSource.Infrastructure.deployproj", "{0F98E939-EC64-40DA-9630-336A40807BBE}"
@@ -98,7 +98,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource.Integrati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.WindowsPackageManager.Rest", "Microsoft.WindowsPackageManager.Rest\Microsoft.WindowsPackageManager.Rest.csproj", "{7AC8DE6B-4B4C-49DA-8444-94FD3BAC4C47}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinGet.RestSource.AppConfig", "WinGet.RestSource.AppConfig\WinGet.RestSource.AppConfig.csproj", "{A8F523C8-2B41-4F77-9DD0-A9FBE72E6B9D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WinGet.RestSource.AppConfig", "WinGet.RestSource.AppConfig\WinGet.RestSource.AppConfig.csproj", "{A8F523C8-2B41-4F77-9DD0-A9FBE72E6B9D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Previous commit breaks the build with:
Targeting .NET 6.0 in Visual Studio 2019 is not supported.

Try retarget to VS 2022