### PR TITLE
Update Test-PowerShellModuleExists.ps1

### DIFF
--- a/Tools/PowershellModule/src/Library/Get-WinGetManifest.ps1
+++ b/Tools/PowershellModule/src/Library/Get-WinGetManifest.ps1
@@ -292,6 +292,7 @@ Function Get-WinGetManifest
                             }
 
                             Write-Verbose -Message "Returned Manifest from YAML file: $($Return.PackageIdentifier)"
+                            Write-Verbose -Message "Returned Manifest from YAML file: $($Return) `n`n$Path`n`n$JSON"
                         }
                         else {
                             Write-Error -Message "Unable to process YAML files. Re-import the module to reload the required dependencies." -Category ResourceUnavailable
@@ -307,7 +308,6 @@ Function Get-WinGetManifest
                                 ManifestFile        = $ManifestFile
                                 $ManifestFileType   = $ManifestFileType
                             }
-
                             Write-Error -Message $ErrorMessage -Category InvalidType -TargetObject $ErrReturnObject
                         }
                     }

--- a/Tools/PowershellModule/src/Library/Test-PowerShellModuleExists.ps1
+++ b/Tools/PowershellModule/src/Library/Test-PowerShellModuleExists.ps1
@@ -57,12 +57,9 @@ Function Test-PowerShellModuleExist
 
                 if(!($ValidationStatus)) {
                     ## Module Validation failed
-                    $ErrorMessage = "Missing required PowerShell modules. Run the following command to install the missing modules: Install-Module Az"
-                    $ErrReturnObject = @{
-                        TestResults = $TestResult
-                    }
+                    $WarnMessage = "Missing required PowerShell modules. Run the following command to install the missing modules: Install-Module Az"
                     
-                    Write-Error -Message $ErrorMessage -Category NotInstalled -TargetObject $ErrReturnObject
+                    Write-WarnMessage -Message $WarnMessage
                 }
             }
             "Single" { 


### PR DESCRIPTION
Error message showed that the Azure modules was missing, but then installs them anyways. This should be a warning and not an error.