### PR TITLE
winget-cli-restsource-ci - 1ES migration

### DIFF
--- a/pipelines/templates/copy-artifacts.yml
+++ b/pipelines/templates/copy-artifacts.yml
@@ -1,0 +1,13 @@
+# Template helper to copy files to artifact staging directory
+parameters:
+  name: ''
+  source: ''
+
+steps:
+- task: CopyFiles@2
+  displayName: 'Copy Files: ${{ parameters.name }}'
+  inputs:
+    SourceFolder: ${{ parameters.source }}
+    TargetFolder:  '$(build.artifactstagingdirectory)\${{ parameters.name }}'
+    CleanTargetFolder: true
+    OverWrite: true

--- a/pipelines/templates/copy-powershell-scripts.yml
+++ b/pipelines/templates/copy-powershell-scripts.yml
@@ -1,0 +1,44 @@
+# Template helper to copy PowerShell scripts and all dependencies
+parameters:
+ helperLibsPath: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\bin\$(BuildConfiguration)\netcoreapp3.1'
+ templatesPath: '$(Build.SourcesDirectory)\src\WinGet.RestSource.Infrastructure\bin\$(BuildConfiguration)\Templates'
+
+steps:
+- task: CopyFiles@2
+  displayName: 'Copy Files: Powershell Module'
+  inputs:
+    SourceFolder: '$(Build.SourcesDirectory)\Tools\PowershellModule\src'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
+    CleanTargetFolder: true
+    OverWrite: true
+
+# Publish Helper Libs - win-x86
+- task: DotNetCoreCLI@2
+  displayName: 'Package Helper Libs: Portable'
+  inputs:
+    command: publish
+    publishWebProjects: false
+    projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\WinGet.RestSource.PowershellSupport.csproj'
+    arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source\Library --no-restore'
+    zipAfterPublish: false
+
+- task: CopyFiles@2
+  displayName: 'Copy Files: Arm Templates'
+  inputs:
+    Contents: ${{ parameters.templatesPath }}\**\*.json
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source\Library\ARMTemplate'
+    OverWrite: true
+    flattenFolders: true
+
+- task: CopyFiles@2
+  displayName: 'Copy Files: azure function'
+  inputs:
+    SourceFolder: '$(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions'
+    TargetFolder: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source\Library\RestAPI'
+    OverWrite: true
+
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
+  inputs:
+    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
+    ArtifactName: 'WinGet.RestSource-Winget.PowerShell.Source'

--- a/pipelines/templates/restore-build-test.yml
+++ b/pipelines/templates/restore-build-test.yml
@@ -1,0 +1,67 @@
+# Template helper to restore, build, and publish
+
+steps:
+
+# Checkout repo with lfs enabled
+- task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+  inputs:
+    repository: self
+    lfs: "true"
+
+## Restore
+- task: DotNetCoreCLI@2
+  displayName: 'Restore'
+  inputs:
+    command: 'restore'
+    projects: '**/*.csproj'
+    feedsToUse: 'config'
+    nugetConfigPath: '$(Build.SourcesDirectory)\src\NuGet.config'
+    restoreDirectory: '$(Build.SourcesDirectory)\src\packages'
+
+## Build
+- task: VSBuild@1
+  displayName: Build
+  inputs:
+    solution: '**\*.sln'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
+    clean: true
+
+## Copy
+# Copy ARM Templates
+- template: pipelines/templates/copy-artifacts.yml@self
+  parameters:
+    name: WinGet.Restsource.Infrastructure
+    source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.Infrastructure\bin\$(BuildConfiguration)'
+
+# Copy scripts
+- template: pipelines/templates/copy-artifacts.yml@self
+  parameters:
+    name: ReleaseScripts
+    source: '$(Build.SourcesDirectory)\scripts\Release'
+
+# Copy Rest Function App
+- template: pipelines/templates/package-and-publish.yml@self
+  parameters:
+    name: WinGet.RestSource.Functions
+    projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.Functions\WinGet.RestSource.Functions.csproj'
+    buildconfig: '$(BuildConfiguration)'
+    zipAfterPublish: True
+
+# Copy Rest Function App
+- template: pipelines/templates/package-and-publish.yml@self
+  parameters:
+    name: WinGet.RestSource.IntegrationTest
+    projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\WinGet.RestSource.IntegrationTest.csproj'
+    buildconfig: '$(BuildConfiguration)'
+    zipAfterPublish: False
+
+# Copy powershell
+- template: pipelines/templates/copy-powershell-scripts.yml@self
+
+## Run Unit Tests
+- template: pipelines/templates/run-unittests.yml@self
+  parameters:
+    name: WinGet.RestSource.UnitTest
+    testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\net6.0'
+    dll: Microsoft.WinGet.RestSource.UnitTest.

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -7,14 +7,17 @@ parameters:
   testDirectory: ''
 
 steps:
-- powershell: |
-    # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
-    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
-
-    # Launch Cosmos DB emulator
-    Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-    Start-CosmosDbEmulator
+- task: PowerShell@2
   displayName: "Setup test pre-requisites"
+  inputs:
+    targetType: inline
+    script: >
+      # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
+      copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
+
+      # Launch Cosmos DB emulator
+      Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+      Start-CosmosDbEmulator
 
 - task: DotNetCoreCLI@2
   displayName: 'Run tests: ${{ parameters.name }}'

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -3,94 +3,109 @@
 
 # Branches that trigger a build on commit
 trigger:
-- main
+  branches:
+    include:
+    - main
 
-jobs:
-- job: 'BuildTestPublish'
-  displayName: 'Build Test & Publish'
-  timeoutInMinutes: 60
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
-  variables:
-    BuildConfiguration: 'release'
-    BuildPlatform: 'Any CPU'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-  steps:
-  # Restore and Build
-  - template: templates/restore-build-publish-test.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-  # Build Analysis - Binary Analysis (must run after build is complete on agent performing build)
-  - template: templates/binSkim.yml
-    parameters:
-      name: winget-pkgs-restsource.BinSkim.ArtifactStagingDirectory
-      binaries: "$(Build.ArtifactStagingDirectory)"
-  
-  # Publish SDT Logs
-  - template: templates/copy-and-publish.yml
-    parameters:
-      name: StaticAnalysisLogs
-      source: '$(Agent.BuildDirectory)\_sdt\logs'
-  
-  # SDT Post Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      BinSkim: true
+    sdl:
+      codeInspector:
+        enabled: true
 
-# Static Analysis Job
-- job: 'StaticAnalysis'
-  displayName: 'Static Analysis'
-  timeoutInMinutes: 120
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
+    stages:
+    - stage: __default
+      jobs:
+      - job: 'BuildTestPublish'
+        displayName: 'Build Test & Publish'
+        timeoutInMinutes: 60
+        variables:
+        - name: BuildConfiguration
+          value: 'release'
+        - name: BuildPlatform
+          value: 'Any CPU'
 
-  steps:
-  # Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-    displayName: 'Run CredScan'
-    inputs:
-      toolMajorVersion: V2
-      debugMode: false
+        steps:
+        # Restore and Build
+        - template: pipelines/templates/restore-build-test.yml@self
 
-  # Semmle Requires Restore on Agent
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet restore'
-    inputs:
-      command: 'restore'
-      projects: '**/*.csproj'
-      feedsToUse: 'config'
-      nugetConfigPath: '$(Build.SourcesDirectory)\src\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\src\packages'
+        templateContext:
+          outputs:
+          # Publish ARM Templates
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.Restsource.Infrastructure'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.Restsource.Infrastructure
+            ArtifactName: WinGet.RestSource-WinGet.Restsource.Infrastructure
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-semmle.Semmle@0
-    displayName: 'Run Semmle'
-    inputs:
-      cleanupBuildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
-      buildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
 
-  # Publish SDT Logs
-  - template: templates/copy-and-publish.yml
-    parameters:
-      name: StaticAnalysisLogs
-      source: '$(Agent.BuildDirectory)\_sdt\logs'
+          # Publish scripts
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-ReleaseScripts'
+            targetPath: $(Build.ArtifactStagingDirectory)\ReleaseScripts
+            ArtifactName: WinGet.RestSource-ReleaseScripts
 
-  # SDT Post Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      CredScan: true
-      Semmle: true
-      $testBinaryPath: 
 
-  # Code Inspector
-  - task: CodeInspector@2
-    inputs:
-      ProductId: 'd2ca06e4-302f-4a16-99e5-27e39570d352'
+          # Publish Rest Function App
+          # package projects
+          - output: nuget
+            displayName: 'Package Azure Function: WinGet.RestSource-WinGet.RestSource.Functions'
+            useDotNetTask: true
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            publishWebProjects: false
+            projects: $(Build.SourcesDirectory)\src\WinGet.RestSource.Functions\WinGet.RestSource.Functions.csproj
+            arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions --no-restore
+            zipAfterPublish: True
+
+          # publish as an artifact
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.Functions'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions
+            ArtifactName: WinGet.RestSource-WinGet.RestSource.Functions
+
+
+          # Publish Rest Function App
+          # package projects
+          - output: nuget
+            displayName: 'Package Azure Function: WinGet.RestSource-WinGet.RestSource.IntegrationTest'
+            useDotNetTask: true
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            publishWebProjects: false
+            projects: $(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\WinGet.RestSource.IntegrationTest.csproj
+            arguments: --configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)\WinGet.RestSource.IntegrationTest --no-restore
+            zipAfterPublish: False
+
+          # publish as an artifact
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.IntegrationTest'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.IntegrationTest
+            ArtifactName: WinGet.RestSource-WinGet.RestSource.IntegrationTest
+
+          # Publish Helper Libs - win-x86
+          - output: nuget
+            displayName: 'Package Helper Libs: Portable'
+            useDotNetTask: true
+            packageParentPath: '$(Build.ArtifactStagingDirectory)'
+            publishWebProjects: false
+            projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.PowershellSupport\WinGet.RestSource.PowershellSupport.csproj'
+            arguments: '--configuration $(BuildConfiguration) --output $(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source\Library --no-restore'
+            zipAfterPublish: false
+
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
+            targetPath: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
+            ArtifactName: 'WinGet.RestSource-Winget.PowerShell.Source'


### PR DESCRIPTION
The commit include:
- Necessary changes introduced by running 1ES Migration tool
- Template updates where necessary to align with Migration tool changes
- Some of the new templates are added for pairty with *-publish.yml but publish operation is mostly handled in the parent winget-cli-restsource-ci.yml
  - copy-artifacts.yml
  - copy-powershell-scripts.yml
  - restore-build-test.yml