### PR TITLE
winget cli restsource 1ES pipeline migration

### DIFF
--- a/pipelines/templates/copy-and-publish-powershell.yml
+++ b/pipelines/templates/copy-and-publish-powershell.yml
@@ -36,9 +36,3 @@ steps:
     SourceFolder: '$(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions'
     TargetFolder: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source\Library\RestAPI'
     OverWrite: true
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
-    ArtifactName: 'WinGet.RestSource-Winget.PowerShell.Source'

--- a/pipelines/templates/copy-and-publish.yml
+++ b/pipelines/templates/copy-and-publish.yml
@@ -11,9 +11,3 @@ steps:
     TargetFolder:  '$(build.artifactstagingdirectory)\${{ parameters.name }}'
     CleanTargetFolder: true
     OverWrite: true
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: WinGet.RestSource-${{ parameters.name }}'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.name }}'
-    ArtifactName: 'WinGet.RestSource-${{ parameters.name }}'

--- a/pipelines/templates/package-and-publish.yml
+++ b/pipelines/templates/package-and-publish.yml
@@ -14,9 +14,3 @@ steps:
     projects: '${{ parameters.projects }}'
     arguments: '--configuration ${{ parameters.buildconfig }} --output $(Build.ArtifactStagingDirectory)\${{ parameters.name }} --no-restore'
     zipAfterPublish: ${{ parameters.zipAfterPublish }}
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: WinGet.RestSource-${{ parameters.name }}'
-  inputs:
-    PathtoPublish: '$(Build.ArtifactStagingDirectory)\${{ parameters.name }}'
-    ArtifactName: 'WinGet.RestSource-${{ parameters.name }}'

--- a/pipelines/templates/restore-build-publish-test.yml
+++ b/pipelines/templates/restore-build-publish-test.yml
@@ -3,8 +3,10 @@
 steps:
 
 # Checkout repo with lfs enabled
-- checkout: self
-  lfs: "true"
+- task: 6d15af64-176c-496d-b583-fd2ae21d4df4@1
+  inputs:
+    repository: self
+    lfs: "true"
 
 ## Restore
 - task: DotNetCoreCLI@2
@@ -27,19 +29,19 @@ steps:
 
 ## Publish
 # Publish ARM Templates
-- template: copy-and-publish.yml
+- template: copy-and-publish.yml@self
   parameters:
     name: WinGet.Restsource.Infrastructure
     source: '$(Build.SourcesDirectory)\src\WinGet.RestSource.Infrastructure\bin\$(BuildConfiguration)'
 
 # Publish scripts
-- template: copy-and-publish.yml
+- template: copy-and-publish.yml@self
   parameters:
     name: ReleaseScripts
     source: '$(Build.SourcesDirectory)\scripts\Release'
 
 # Publish Rest Function App
-- template: package-and-publish.yml
+- template: package-and-publish.yml@self
   parameters:
     name: WinGet.RestSource.Functions
     projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.Functions\WinGet.RestSource.Functions.csproj'
@@ -47,7 +49,7 @@ steps:
     zipAfterPublish: True
 
 # Publish Rest Function App
-- template: package-and-publish.yml
+- template: package-and-publish.yml@self
   parameters:
     name: WinGet.RestSource.IntegrationTest
     projects: '$(Build.SourcesDirectory)\src\WinGet.RestSource.IntegrationTest\WinGet.RestSource.IntegrationTest.csproj'
@@ -55,20 +57,11 @@ steps:
     zipAfterPublish: False
 
 # Publish powershell
-- template: copy-and-publish-powershell.yml
+- template: copy-and-publish-powershell.yml@self
 
 ## Run Unit Tests
-- template: run-unittests.yml
+- template: run-unittests.yml@self
   parameters:
     name: WinGet.RestSource.UnitTest
     testDirectory: '$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\bin\$(BuildConfiguration)\net6.0'
     dll: Microsoft.WinGet.RestSource.UnitTest.
-
-## Component Governance
-- task: ComponentGovernanceComponentDetection@0
-  displayName: Component Governance
-  inputs:
-    scanType: 'Register'
-    verbosity: 'Verbose'
-    alertWarningLevel: 'High'
-    failOnAlert: true

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -6,15 +6,17 @@ parameters:
   dll: ''
   testDirectory: ''
 
-steps:
-- powershell: |
+- task: PowerShell@2
+  displayName: "Setup test pre-requisites"
+  inputs:
+    targetType: inline
+    script: >
     # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
     copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
 
     # Launch Cosmos DB emulator
     Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
     Start-CosmosDbEmulator
-  displayName: "Setup test pre-requisites"
 
 - task: DotNetCoreCLI@2
   displayName: 'Run tests: ${{ parameters.name }}'

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -11,7 +11,7 @@ steps:
   displayName: "Setup test pre-requisites"
   inputs:
     targetType: inline
-    script: >
+    script: |
       # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
       copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
 

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -12,12 +12,12 @@ steps:
   inputs:
     targetType: inline
     script: >
-    # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
-    copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
+      # Copy and rename Test.runsettings.template.json to Test.runsettings.json to be used as test config
+      copy "$(Build.SourcesDirectory)\src\WinGet.RestSource.UnitTest\Test.runsettings.template.json" "${{ parameters.testDirectory }}\Test.runsettings.json"
 
-    # Launch Cosmos DB emulator
-    Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
-    Start-CosmosDbEmulator
+      # Launch Cosmos DB emulator
+      Import-Module "$env:ProgramFiles\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
+      Start-CosmosDbEmulator
 
 - task: DotNetCoreCLI@2
   displayName: 'Run tests: ${{ parameters.name }}'

--- a/pipelines/templates/run-unittests.yml
+++ b/pipelines/templates/run-unittests.yml
@@ -6,6 +6,7 @@ parameters:
   dll: ''
   testDirectory: ''
 
+steps:
 - task: PowerShell@2
   displayName: "Setup test pre-requisites"
   inputs:

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -2,7 +2,8 @@
 # CI pipeline for winget-cli-restsource
 
 # Standard Triggers
-trigger: none
+trigger:
+  enabled: false
 
 # PR triggers
 pr:
@@ -21,51 +22,67 @@ variables:
 - name: DisablePipelineConfigDetector
   value: true
 
-jobs:
-- job: 'BuildPublishTest'
-  displayName: 'Build Publish & Tests'
-  timeoutInMinutes: 60
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
-  variables:
-    BuildConfiguration: 'release'
-    BuildPlatform: 'Any CPU'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-  steps:
-  # Restore and Build
-  - template: templates/restore-build-publish-test.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-# Static Analysis Job
-- job: 'StaticAnalysis'
-  displayName: 'Static Analysis'
-  timeoutInMinutes: 60
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
+    stages:
+    - stage: __default
+      jobs:
+      - job: 'BuildPublishTest'
+        displayName: 'Build Publish & Tests'
+        timeoutInMinutes: 60
+        variables:
+        - name: BuildConfiguration
+          value: 'release'
+        - name: BuildPlatform
+          value: 'Any CPU'
 
-  steps:
-  # Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-    displayName: 'Run CredScan'
-    inputs:
-      toolMajorVersion: V2
-      debugMode: false
+        steps:
+        # Restore and Build
+        - template: pipelines/templates/restore-build-publish-test.yml@self
 
-  # Publish SDT Logs
-  - template: templates/copy-and-publish.yml
-    parameters:
-      name: StaticAnalysisLogs
-      source: '$(Agent.BuildDirectory)\_sdt\logs'
+        templateContext:
+          outputs:
+          # Publish ARM Templates
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.Restsource.Infrastructure'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.Restsource.Infrastructure
+            artifactName: WinGet.RestSource-WinGet.Restsource.Infrastructure
 
-  # SDT Post Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      CredScan: true
+          # Publish scripts
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-ReleaseScripts'
+            targetPath: $(Build.ArtifactStagingDirectory)\ReleaseScripts
+            artifactName: WinGet.RestSource-ReleaseScripts
+
+          # Publish Rest Function App
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.Functions'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions
+            artifactName: WinGet.RestSource-WinGet.RestSource.Functions
+
+          # Publish Rest Function App as an artifact 
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.IntegrationTest'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.IntegrationTest
+            artifactName: WinGet.RestSource-WinGet.RestSource.IntegrationTest
+
+          # Publish Powershell Module
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
+            targetPath: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
+            artifactName: 'WinGet.RestSource-Winget.PowerShell.Source'

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -29,7 +29,7 @@ resources:
     ref: refs/tags/release
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -40,7 +40,7 @@ extends:
     - ES365AIMigrationTooling
 
     stages:
-    - stage: Build Publish Test & Guardian Checks
+    - stage: Build_Publish_Test_And_GuardianChecks
       jobs:
       - job: 'BuildPublishTest'
         displayName: 'Build Publish & Tests'

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -2,8 +2,7 @@
 # CI pipeline for winget-cli-restsource
 
 # Standard Triggers
-trigger:
-  enabled: false
+trigger: none
 
 # PR triggers
 pr:

--- a/pipelines/winget-cli-restsource-ci-pr.yml
+++ b/pipelines/winget-cli-restsource-ci-pr.yml
@@ -36,10 +36,11 @@ extends:
       image: windows-2022
       os: windows
     customBuildTags:
+    # This is added my 1ES migration tool and it is okay to remove in the future.
     - ES365AIMigrationTooling
 
     stages:
-    - stage: __default
+    - stage: Build Publish Test & Guardian Checks
       jobs:
       - job: 'BuildPublishTest'
         displayName: 'Build Publish & Tests'

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -30,7 +30,7 @@ extends:
         enabled: true
 
     stages:
-    - stage: Build Publish Test & Guardian Checks
+    - stage: Build_Publish_Test_And_GuardianChecks
       jobs:
       - job: 'BuildTestPublish'
         displayName: 'Build Test & Publish'

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -22,6 +22,7 @@ extends:
       image: windows-2022
       os: windows
     customBuildTags:
+    # This is added my 1ES migration tool and it is okay to remove in the future.
     - ES365AIMigrationTooling
 
     sdl:
@@ -29,7 +30,7 @@ extends:
         enabled: true
 
     stages:
-    - stage: __default
+    - stage: Build Publish Test & Guardian Checks
       jobs:
       - job: 'BuildTestPublish'
         displayName: 'Build Test & Publish'

--- a/pipelines/winget-cli-restsource-ci.yml
+++ b/pipelines/winget-cli-restsource-ci.yml
@@ -3,94 +3,75 @@
 
 # Branches that trigger a build on commit
 trigger:
-- main
+  branches:
+    include:
+    - main
 
-jobs:
-- job: 'BuildTestPublish'
-  displayName: 'Build Test & Publish'
-  timeoutInMinutes: 60
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
-  variables:
-    BuildConfiguration: 'release'
-    BuildPlatform: 'Any CPU'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-  steps:
-  # Restore and Build
-  - template: templates/restore-build-publish-test.yml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-2022
+      os: windows
+    customBuildTags:
+    - ES365AIMigrationTooling
 
-  # Build Analysis - Binary Analysis (must run after build is complete on agent performing build)
-  - template: templates/binSkim.yml
-    parameters:
-      name: winget-pkgs-restsource.BinSkim.ArtifactStagingDirectory
-      binaries: "$(Build.ArtifactStagingDirectory)"
-  
-  # Publish SDT Logs
-  - template: templates/copy-and-publish.yml
-    parameters:
-      name: StaticAnalysisLogs
-      source: '$(Agent.BuildDirectory)\_sdt\logs'
-  
-  # SDT Post Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      BinSkim: true
+    sdl:
+      codeInspector:
+        enabled: true
 
-# Static Analysis Job
-- job: 'StaticAnalysis'
-  displayName: 'Static Analysis'
-  timeoutInMinutes: 120
-  pool:
-    name: 'Azure Pipelines'
-    vmImage: windows-latest
-    demands:
-    - msbuild
-    - visualstudio
+    stages:
+    - stage: __default
+      jobs:
+      - job: 'BuildTestPublish'
+        displayName: 'Build Test & Publish'
+        timeoutInMinutes: 60
+        variables:
+        - name: BuildConfiguration
+          value: 'release'
+        - name: BuildPlatform
+          value: 'Any CPU'
 
-  steps:
-  # Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
-    displayName: 'Run CredScan'
-    inputs:
-      toolMajorVersion: V2
-      debugMode: false
+        steps:
+        # Restore and Build
+        - template: pipelines/templates/restore-build-publish-test.yml@self
 
-  # Semmle Requires Restore on Agent
-  - task: DotNetCoreCLI@2
-    displayName: 'dotnet restore'
-    inputs:
-      command: 'restore'
-      projects: '**/*.csproj'
-      feedsToUse: 'config'
-      nugetConfigPath: '$(Build.SourcesDirectory)\src\NuGet.config'
-      restoreDirectory: '$(Build.SourcesDirectory)\src\packages'
+        templateContext:
+          outputs:
+          # Publish ARM Templates
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.Restsource.Infrastructure'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.Restsource.Infrastructure
+            artifactName: WinGet.RestSource-WinGet.Restsource.Infrastructure
+          
+          # Publish scripts
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-ReleaseScripts'
+            targetPath: $(Build.ArtifactStagingDirectory)\ReleaseScripts
+            artifactName: WinGet.RestSource-ReleaseScripts
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-semmle.Semmle@0
-    displayName: 'Run Semmle'
-    inputs:
-      cleanupBuildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln /t:Clean'
-      buildCommands: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\msbuild.exe" $(Build.SourcesDirectory)\src\WinGet.RestSource.sln'
+          # Publish Rest Function App
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.Functions'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.Functions
+            artifactName: WinGet.RestSource-WinGet.RestSource.Functions
 
-  # Publish SDT Logs
-  - template: templates/copy-and-publish.yml
-    parameters:
-      name: StaticAnalysisLogs
-      source: '$(Agent.BuildDirectory)\_sdt\logs'
-
-  # SDT Post Analysis
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
-    displayName: 'Post Analysis'
-    inputs:
-      CredScan: true
-      Semmle: true
-      $testBinaryPath: 
-
-  # Code Inspector
-  - task: CodeInspector@2
-    inputs:
-      ProductId: 'd2ca06e4-302f-4a16-99e5-27e39570d352'
+          # Publish Rest Function App as an artifact 
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-WinGet.RestSource.IntegrationTest'
+            targetPath: $(Build.ArtifactStagingDirectory)\WinGet.RestSource.IntegrationTest
+            artifactName: WinGet.RestSource-WinGet.RestSource.IntegrationTest
+          
+          # Publish Powershell Module
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: WinGet.RestSource-Winget.PowerShell.Source'
+            targetPath: '$(Build.ArtifactStagingDirectory)\Winget.PowerShell.Source'
+            artifactName: 'WinGet.RestSource-Winget.PowerShell.Source'


### PR DESCRIPTION
The changes includes:

- 1ES Pipeline migration changes to
  - winget-cli-restsource-ci-pr.yml
  - winget-cli-restsource-ci.yml
  - templates
    - copy-and-publish-powershell.yml
    - copy-and-publish.yml
    - package-and-publish.yml
    - run-unittests.yml
- Primary noticeable changes
  - Use of 1ES YAML extension templates
 - Eliminating SDT tasks because they are mostly included in the 1ES templates
    - binskim
    - credscan
    - SDT analyis
    - Component Governance
  - The templatecontext now contains all the outputs from the publish tasks that were done by PublishBuildArtifacts@1.

  
[How Validated:]
- Manually trigger the pipeline that contains this change and verify that it functions as before
  - https://dev.azure.com/ms/winget-cli-restsource/_build/results?buildId=506419&view=results
  - https://dev.azure.com/ms/winget-cli-restsource/_build/results?buildId=506425&view=results
 - Compared the artifacts from the pipeline run with those from the old functioning pipeline to validate them as before

