### PR TITLE
Fix build errors by calling WinGetValidateV3 

### DIFF
--- a/src/WinGet.RestSource.PowershellSupport/YamlToRestConverter.cs
+++ b/src/WinGet.RestSource.PowershellSupport/YamlToRestConverter.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="YamlToRestConverter.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -11,7 +11,8 @@ namespace Microsoft.WinGet.RestSource.PowershellSupport
     using System.Linq;
     using Microsoft.WinGet.RestSource.PowershellSupport.Helpers;
     using Microsoft.WinGet.RestSource.Utils.Models.Schemas;
-    using Microsoft.WinGetUtil.Helpers;
+    using Microsoft.WinGetUtil.Api;
+    using Microsoft.WinGetUtil.Common;
     using Microsoft.WinGetUtil.Models.V1;
     using Newtonsoft.Json;
 
@@ -24,7 +25,7 @@ namespace Microsoft.WinGet.RestSource.PowershellSupport
         /// <summary>
         /// Processes a directory for yaml manifests and converts it into the rest json format.
         /// </summary>
-        /// <param name="directory">direcoty to process. Should contain the manifests for a single app.</param>
+        /// <param name="directory">Directory to process. Should contain the manifests for a single app.</param>
         /// <param name="priorRestManifest">Prior json data to merge with.</param>
         /// <returns>A string of the rest source json.</returns>
         public static string AddManifestToPackageManifest(
@@ -39,14 +40,10 @@ namespace Microsoft.WinGet.RestSource.PowershellSupport
                             Path.GetRandomFileName() + ".yaml");
             if (packageFiles.Length > 1)
             {
-                // Multi File manifest case
-                // The winget client ValidateManifest function
-                // merges the manifests into the merged manifest format.
-                (bool succeeded, _) = WinGetUtilWrapperManifest.ValidateManifest(
-                    directory,
-                    mergedManifestFilePath);
+                var factory = new WinGetFactory();
+                using var manifestResult = factory.CreateManifest(directory, mergedManifestFilePath, WinGetCreateManifestOption.SchemaAndSemanticValidation);
 
-                if (!succeeded)
+                if (!manifestResult.IsValid)
                 {
                     throw new Exception("Unable to validate manifest");
                 }

--- a/src/WinGet.RestSource.PowershellSupport/YamlToRestConverter.cs
+++ b/src/WinGet.RestSource.PowershellSupport/YamlToRestConverter.cs
@@ -40,12 +40,13 @@ namespace Microsoft.WinGet.RestSource.PowershellSupport
                             Path.GetRandomFileName() + ".yaml");
             if (packageFiles.Length > 1)
             {
+                // Create merged manifest from multifile manifests.
                 var factory = new WinGetFactory();
-                using var manifestResult = factory.CreateManifest(directory, mergedManifestFilePath, WinGetCreateManifestOption.SchemaAndSemanticValidation);
+                using var manifestResult = factory.CreateManifest(directory, mergedManifestFilePath, WinGetCreateManifestOption.NoValidation);
 
                 if (!manifestResult.IsValid)
                 {
-                    throw new Exception("Unable to validate manifest");
+                    throw new Exception("Unable to create merged manifest from multifile manifests.");
                 }
             }
             else

--- a/src/WinGet.RestSource.UnitTest/Tests/PowerShellSupport/YamlToRestConverterTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/PowerShellSupport/YamlToRestConverterTests.cs
@@ -1,4 +1,4 @@
-// -----------------------------------------------------------------------
+﻿// -----------------------------------------------------------------------
 // <copyright file="YamlToRestConverterTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>

--- a/src/WinGet.RestSource.UnitTest/Tests/PowerShellSupport/YamlToRestConverterTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/PowerShellSupport/YamlToRestConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="YamlToRestConverterTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>


### PR DESCRIPTION
The latest update to WinGetUtils no longer has `WinGetUtilWrapperManifest.ValidateManifest`. This PR fixes that issue by updating to calling WinGetValidateV3