### PR TITLE
Use managed identities for AzureWebJobsStorage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+!scripts/Release/
+
 # These are the PowerShell helper libraries used to run. Added to artifact as automated task
 Tools/PowershellModule/src/Library/ARMTemplate
 Tools/PowershellModule/src/Library/RestAPI

--- a/scripts/Release/service_principals_roles.ps1
+++ b/scripts/Release/service_principals_roles.ps1
@@ -1,0 +1,59 @@
+<#
+.SYNOPSIS
+    Sets roles to a service principals
+.DESCRIPTION
+    Sets roles to service principals given a json file with the definitions.
+#>
+Param(
+    [Parameter(Mandatory=$true)]
+    [String]
+    $subscriptionId,
+
+    [Parameter(Mandatory=$true)]
+    [String]
+    $resourceGroup,
+
+    [Parameter(Mandatory=$true)]
+    [String]
+    $rolesFile,
+
+    [Switch]
+    $showWarnings
+)
+
+Set-AzContext -SubscriptionId $subscriptionId | Out-Null
+$local:data = Get-Content $rolesFile -Raw | ConvertFrom-Json
+
+foreach ($storageAccount in $data.storageAccounts)
+{
+    $private:scope = "/subscriptions/$subscriptionId/resourceGroups/$resourceGroup/providers/Microsoft.Storage/storageAccounts/$($storageAccount.name)"
+
+    foreach ($sp in $storageAccount.servicePrincipals)
+    {
+        Write-Host "Configuring $($sp.displayName) in $($storageAccount.name)"
+        $private:objectId = (Get-AzADServicePrincipal -DisplayName $($sp.displayName)).Id
+
+        if ($null -eq $objectId)
+        {
+            Write-Error "Cannot find $($sp.displayName)"
+            continue
+        }
+
+        $private:currentRoles = Get-AzRoleAssignment -ObjectId $objectId -Scope $scope
+        foreach ($role in $sp.roles)
+        {
+            $private:exists = $currentRoles | Where-Object { $_.RoleDefinitionName -eq $role }
+            if ($null -eq $exists)
+            {
+                New-AzRoleAssignment -ObjectID $objectId -RoleDefinitionName $role -Scope $scope
+            }
+            else
+            {
+                if ($showWarnings)
+                {
+                    Write-Warning "$($sp.displayName) already has '$role' assigned to $($storageAccount.name)"
+                }
+            }
+        }
+    }
+}

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.centus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestcentusint"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.westus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestwestusint"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.centus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestcentuspme"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.westus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestwestuspme"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.centus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestcentusppe"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.westus.json
@@ -51,6 +51,9 @@
         ],
         "supportCredentials": false
       }
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestwestusppe"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.test.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.test.westus.json
@@ -40,6 +40,9 @@
     },
     "monitoringMetricsAccount": {
       "value": "MsPkgMgrMetrics"
+    },
+    "azFuncStorageName": {
+      "value": "stwgrestwestustest"
     }
   }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.test.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.test.json
@@ -31,7 +31,7 @@
         },
         {
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "objectId": "94068ac3-3b3c-4ce5-8f6d-b0ec26875e07",
+          "objectId": "789c9442-e61d-48ea-84e1-02892ef4651f",
           "permissions": {
             "keys": [
               "Get",
@@ -51,7 +51,7 @@
             ]
           },
           "metadata": {
-            "description": "This is the object for DEP-APT-WinGetService-Test (winget-cli-restsource)."
+            "description": "This is the object for winget-cli-restsource Test."
           }
         },
         {

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
@@ -1,0 +1,38 @@
+{
+    "storageAccounts": [
+        {
+            "description": "This is the storage account for the west azure function",
+            "name": "stwgrestwestusint",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-westus-int",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "This is the storage account for the central us azure function",
+            "name": "stwgrestcentusint",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-centus-int",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
@@ -1,0 +1,38 @@
+{
+    "storageAccounts": [
+        {
+            "description": "This is the storage account for the west azure function",
+            "name": "stwgrestwestuspme",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-centus-pme",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "This is the storage account for the central us azure function",
+            "name": "stwgrestcentuspme",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-westus-pme",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
@@ -1,0 +1,38 @@
+{
+    "storageAccounts": [
+        {
+            "description": "This is the storage account for the west azure function",
+            "name": "stwgrestwestusppe",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-westus-ppe",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        },
+        {
+            "description": "This is the storage account for the central us azure function",
+            "name": "stwgrestcentusppe",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-centus-ppe",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
@@ -1,0 +1,21 @@
+{
+    "storageAccounts": [
+        {
+            "description": "This is the storage account for the west azure function",
+            "name": "stwgrestwestustest",
+            "servicePrincipals": [
+                {
+                    "displayName": "azfun-wgrest-api-westus-test",
+                    "roles": [
+                        "Storage Account Contributor",
+                        "Storage Blob Data Owner",
+                        "Storage Table Data Contributor",
+                        "Storage Queue Data Contributor",
+                        "Storage Queue Data Message Sender",
+                        "Storage Queue Data Message Processor"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
+++ b/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
@@ -68,7 +68,13 @@
         "storageSecretName": {
             "type": "string",
             "metadata": {
-                "description": "Storage Secret Name"
+                "description": "Storage Secret Name. TODO: delete this once WEBSITE_CONTENTAZUREFILECONNECTIONSTRING managed identity support is enabled"
+            }
+        },
+        "azFuncStorageName": {
+            "type": "string",
+            "metadata": {
+                "description": "The name of the storage account used for Az Func operations. This Az Func must have the permissions required. See roles.*.json under StorageAccount"
             }
         },
         "appInsightSubscription": {
@@ -245,7 +251,7 @@
                     "properties": {
                         "APPINSIGHTS_INSTRUMENTATIONKEY": "[reference(variables('appInsightResourceId'), '2015-05-01').InstrumentationKey]",
                         "AzFuncRestSourceEndpoint": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_restSourceApiEndpoint_SecretName'), '/)')]",
-                        "AzureWebJobsStorage": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), parameters('storageSecretName'), '/)')]",
+                        "AzureWebJobsStorage__accountName": "[parameters('azFuncStorageName')]",
                         "CertificateAuthenticationRequired": "[variables('certificateAuthenticationEnabled')]",
                         "CertificateAuthenticationSelfSigned": "[parameters('certificateAuthenticationAllowSelfSigned')]",
                         "CertificateAuthenticationSubjectName": "[parameters('certificateAuthenticationSubjectName')]",


### PR DESCRIPTION
This change removes the use of the Storage Account connection string in Azure Funcions for AzureWebJobsStorage. This is not a full move to managed identities because WEBSITE_CONTENTAZUREFILECONNECTIONSTRING still doesn't support them.