### PR TITLE
Update rotation script and Azure Durable functions

### DIFF
--- a/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
+++ b/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="3.0.10" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.4.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
   </ItemGroup>
 
   <!-- Component Governance fix Item Group. -->

--- a/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.int.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.int.json
@@ -30,7 +30,7 @@
         },
         {
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "objectId": "3aec9770-cb67-4244-8a11-fb86b4bc4988",
+          "objectId": "4d43284b-69df-4fda-938c-9636be4248bc",
           "permissions": {
             "keys": [
               "Get",
@@ -50,7 +50,7 @@
             ]
           },
           "metadata": {
-            "description": "This is the object for DEP-APT-WinGetService-Internal (winget-cli-restsource)."
+            "description": "This is the object for winget-cli-restsource Int."
           }
         },
         {

--- a/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.ppe.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.ppe.json
@@ -30,7 +30,7 @@
         },
         {
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "objectId": "f9c437e7-f49e-4226-81eb-0944531afa02",
+          "objectId": "a2db5783-1f5a-4db7-a228-f86910ed981a",
           "permissions": {
             "keys": [
               "Get",
@@ -50,7 +50,7 @@
             ]
           },
           "metadata": {
-            "description": "This is the object for DEP-APT-WinGetService-PPE (winget-cli-restsource)."
+            "description": "This is the object for winget-cli-restsource PPE."
           }
         },
         {


### PR DESCRIPTION
This PR

1. Fix rotation script. While we are in the process of moving away from connection strings, we still need them while Azure Files implement support using managed identity. The rotation script is outdated as `az keyvault storage` is deprecated so the command doesn't exist in the az cli of the agents. This cmd was useful as it gives you which is the active key to be used for the connection string. Instead we just figure out which one is the oldest one set it in the key vault.
2. Add new OIDs for service principals
3. Update nuget package for Azure Durable functions.
