### PR TITLE
Use WEBSITE_RUN_FROM_PACKAGE in azure functions for deployment

### DIFF
--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.deployment.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.deployment.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "runFromPackageUrl": {
+            "value": ""
+        }
+    }
+}

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.centus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-centus-int"
     },
-    "storageSecretName": {
-      "value": "stwgrestcentusintConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-centus-int"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.int.westus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-westus-int"
     },
-    "storageSecretName": {
-      "value": "stwgrestwestusintConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-westus-int"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.centus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-centus-pme"
     },
-    "storageSecretName": {
-      "value": "stwgrestcentuspmeConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-centus-pme"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.pme.westus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-westus-pme"
     },
-    "storageSecretName": {
-      "value": "stwgrestwestuspmeConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-westus-pme"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.centus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-centus-ppe"
     },
-    "storageSecretName": {
-      "value": "stwgrestcentusppeConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-centus-ppe"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.ppe.westus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-westus-ppe"
     },
-    "storageSecretName": {
-      "value": "stwgrestwestusppeConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-westus-ppe"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.test.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/AzureFunction/azurefunction.test.westus.json
@@ -20,9 +20,6 @@
     "functionName": {
       "value": "azfun-wgrest-api-westus-test"
     },
-    "storageSecretName": {
-      "value": "stwgrestwestustestConnectionString"
-    },
     "appServiceName": {
       "value": "asp-wgrest-westus-test"
     },

--- a/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.test.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/KeyVault/keyvault.test.json
@@ -31,27 +31,21 @@
         },
         {
           "tenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
-          "objectId": "789c9442-e61d-48ea-84e1-02892ef4651f",
+          "objectId": "b403b8bc-5f45-410d-9a87-e71bb4b11f81",
           "permissions": {
             "keys": [
-              "Get",
-              "List"
             ],
             "secrets": [
               "Get",
-              "List",
-              "Set"
-            ],
-            "certificates": [
-              "Get",
               "List"
             ],
+            "certificates": [
+            ],
             "storage": [
-              "Get"
             ]
           },
           "metadata": {
-            "description": "This is the object for winget-cli-restsource Test."
+            "description": "This is the object for mi-wgrest-deployment-test. Used for E2E."
           }
         },
         {

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
@@ -53,7 +53,7 @@
             "name": "appconfig-wgrest-centus-int",
             "servicePrincipals": [
                 {
-                    "displayName": "winget-cli-restsource Int",
+                    "displayName": "mi-wgrest-deployment-int",
                     "roles": [
                         "App Configuration Data Owner"
                     ]
@@ -77,7 +77,7 @@
             "name": "appconfig-wgrest-westus-int",
             "servicePrincipals": [
                 {
-                    "displayName": "winget-cli-restsource Int",
+                    "displayName": "mi-wgrest-deployment-int",
                     "roles": [
                         "App Configuration Data Owner"
                     ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.int.json
@@ -5,6 +5,12 @@
             "name": "stwgrestwestusint",
             "servicePrincipals": [
                 {
+                    "displayName": "mi-wgrest-deployment-int",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
+                {
                     "displayName": "azfun-wgrest-api-westus-int",
                     "roles": [
                         "Storage Account Contributor",
@@ -21,6 +27,12 @@
             "description": "This is the storage account for the central us azure function",
             "name": "stwgrestcentusint",
             "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-int",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
                 {
                     "displayName": "azfun-wgrest-api-centus-int",
                     "roles": [
@@ -80,6 +92,20 @@
                     "displayName": "azfun-wgrest-api-westus-int",
                     "roles": [
                         "App Configuration Data Reader"
+                    ]
+                }
+            ]
+        }
+    ],
+    "subscription" : [
+        {
+            "description": "Roles at subscription level",
+            "name": "subscription",
+            "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-int",
+                    "roles": [
+                        "Reader"
                     ]
                 }
             ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
@@ -53,7 +53,7 @@
             "name": "appconfig-wgrest-centus-pme",
             "servicePrincipals": [
                 {
-                    "displayName": "WDX-APT-WPMService (winget-cli-restsource)",
+                    "displayName": "mi-wgrest-deployment-pme",
                     "roles": [
                         "App Configuration Data Owner"
                     ]
@@ -77,7 +77,7 @@
             "name": "appconfig-wgrest-westus-pme",
             "servicePrincipals": [
                 {
-                    "displayName": "WDX-APT-WPMService (winget-cli-restsource)",
+                    "displayName": "mi-wgrest-deployment-pme",
                     "roles": [
                         "App Configuration Data Owner"
                     ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.pme.json
@@ -5,6 +5,12 @@
             "name": "stwgrestwestuspme",
             "servicePrincipals": [
                 {
+                    "displayName": "mi-wgrest-deployment-pme",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
+                {
                     "displayName": "azfun-wgrest-api-westus-pme",
                     "roles": [
                         "Storage Account Contributor",
@@ -21,6 +27,12 @@
             "description": "This is the storage account for the central us azure function",
             "name": "stwgrestcentuspme",
             "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-pme",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
                 {
                     "displayName": "azfun-wgrest-api-centus-pme",
                     "roles": [
@@ -80,6 +92,20 @@
                     "displayName": "azfun-wgrest-api-westus-pme",
                     "roles": [
                         "App Configuration Data Reader"
+                    ]
+                }
+            ]
+        }
+    ],
+    "subscription" : [
+        {
+            "description": "Roles at subscription level",
+            "name": "subscription",
+            "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-pme",
+                    "roles": [
+                        "Reader"
                     ]
                 }
             ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
@@ -5,6 +5,12 @@
             "name": "stwgrestwestusppe",
             "servicePrincipals": [
                 {
+                    "displayName": "mi-wgrest-deployment-ppe",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
+                {
                     "displayName": "azfun-wgrest-api-westus-ppe",
                     "roles": [
                         "Storage Account Contributor",
@@ -21,6 +27,12 @@
             "description": "This is the storage account for the central us azure function",
             "name": "stwgrestcentusppe",
             "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-ppe",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
                 {
                     "displayName": "azfun-wgrest-api-centus-ppe",
                     "roles": [
@@ -80,6 +92,20 @@
                     "displayName": "azfun-wgrest-api-westus-ppe",
                     "roles": [
                         "App Configuration Data Reader"
+                    ]
+                }
+            ]
+        }
+    ],
+    "subscription" : [
+        {
+            "description": "Roles at subscription level",
+            "name": "subscription",
+            "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-ppe",
+                    "roles": [
+                        "Reader"
                     ]
                 }
             ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.ppe.json
@@ -53,7 +53,7 @@
             "name": "appconfig-wgrest-centus-ppe",
             "servicePrincipals": [
                 {
-                    "displayName": "winget-cli-restsource PPE",
+                    "displayName": "mi-wgrest-deployment-ppe",
                     "roles": [
                         "App Configuration Data Owner"
                     ]
@@ -77,7 +77,7 @@
             "name": "appconfig-wgrest-westus-ppe",
             "servicePrincipals": [
                 {
-                    "displayName": "winget-cli-restsource PPE",
+                    "displayName": "mi-wgrest-deployment-ppe",
                     "roles": [
                         "App Configuration Data Owner"
                     ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
@@ -30,7 +30,7 @@
             "name": "appconfig-wgrest-westus-test",
             "servicePrincipals": [
                 {
-                    "displayName": "winget-cli-restsource Test",
+                    "displayName": "mi-wgrest-deployment-test",
                     "roles": [
                         "App Configuration Data Owner"
                     ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/Roles/roles.test.json
@@ -5,6 +5,12 @@
             "name": "stwgrestwestustest",
             "servicePrincipals": [
                 {
+                    "displayName": "mi-wgrest-deployment-test",
+                    "roles": [
+                        "Storage Blob Data Contributor"
+                    ]
+                },
+                {
                     "displayName": "azfun-wgrest-api-westus-test",
                     "roles": [
                         "Storage Account Contributor",
@@ -33,6 +39,20 @@
                     "displayName": "azfun-wgrest-api-westus-test",
                     "roles": [
                         "App Configuration Data Reader"
+                    ]
+                }
+            ]
+        }
+    ],
+    "subscription" : [
+        {
+            "description": "Roles at subscription level",
+            "name": "subscription",
+            "servicePrincipals": [
+                {
+                    "displayName": "mi-wgrest-deployment-test",
+                    "roles": [
+                        "Reader"
                     ]
                 }
             ]

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.int.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.int.centus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestcentusint"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.int.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.int.westus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestwestusint"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.pme.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.pme.centus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestcentuspme"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.pme.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.pme.westus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestwestuspme"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.ppe.centus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.ppe.centus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestcentusppe"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.ppe.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.ppe.westus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestwestusppe"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.test.westus.json
+++ b/src/WinGet.RestSource.Infrastructure/Parameters/StorageAccount/storageaccount.test.westus.json
@@ -7,6 +7,14 @@
         },
         "storageAccountName": {
             "value": "stwgrestwestustest"
+        },
+        "containerNames": {
+            "value": [
+                {
+                    "name": "deployments",
+                    "publicAccess": "None"
+                }
+            ]
         }
     }
 }

--- a/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
+++ b/src/WinGet.RestSource.Infrastructure/Templates/AzureFunction/azurefunction.json
@@ -65,12 +65,6 @@
                 "description": "Key Vault Name"
             }
         },
-        "storageSecretName": {
-            "type": "string",
-            "metadata": {
-                "description": "Storage Secret Name. TODO: delete this once WEBSITE_CONTENTAZUREFILECONNECTIONSTRING managed identity support is enabled"
-            }
-        },
         "azFuncStorageName": {
             "type": "string",
             "metadata": {
@@ -196,6 +190,12 @@
             "metadata": {
                 "description": "Monitoring Role"
             }
+        },
+        "runFromPackageUrl": {
+            "type": "string",
+            "metadata": {
+                "description": "The url of the zip package of this azure function. The az function must have at least Storage Blob Data Reader role to the storage account."
+            }
         }
     },
     "variables": {
@@ -264,8 +264,6 @@
                         "FUNCTIONS_WORKER_RUNTIME": "dotnet",
                         "ManifestCacheEndpoint": "[parameters('manifestCacheEndpoint')]",
                         "ServerIdentifier": "[parameters('serverIdentifier')]",
-                        "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), parameters('storageSecretName'), '/)')]",
-                        "WEBSITE_CONTENTSHARE": "[toLower(parameters('functionName'))]",
                         "WEBSITE_FIRST_PARTY_ID": "AntMDS",
                         "WEBSITE_LOAD_CERTIFICATES": "[parameters('website_load_certificates')]",
                         "WinGet:AppConfig:PrimaryEndpoint": "[concat('@Microsoft.KeyVault(SecretUri=', variables('kv_secreturi_path'), variables('kv_appConfigPrimary_SecretName'), '/)')]",

--- a/src/WinGet.RestSource.Infrastructure/Templates/StorageAccount/storageaccount.json
+++ b/src/WinGet.RestSource.Infrastructure/Templates/StorageAccount/storageaccount.json
@@ -93,7 +93,8 @@
                         }
                     },
                     "keySource": "Microsoft.Storage"
-                }
+                },
+                "allowSharedKeyAccess": false
             },
             "kind": "[parameters('kind')]"
         },


### PR DESCRIPTION
Azure Storage File Share doesn’t currently support managed identities. This is used by the `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` environment variable and is required for azure functions that use a consumption plan.

There is a work around to use `WEBSITE_RUN_FROM_PACKAGE` where one needs to upload the azure function zip package into an storage account that is accessible to the function app. The main downside is that there is a 15 seconds cold start.

For this to work the release needs to be modified to not use the AzFunc deploy task as it is not supported. We have a task group that is specialized in azure function deployment. I modified that task with the following.
- Upload the zip package into the storage account used for the function. I'm uploading it into a deployments container and the name is the `$(Release.ReleaseName)-$(Release.AttemptNumber).zip` name to keep it unique.
- Set `WEBSITE_RUN_FROM_PACKAGE` to the full url of the blob in the container. For this, I'm taking advantage of the multiple parameter files deployment to dynamically generate a parameters file with the new `runFromPackageUrl` parameter by deserializing `azurefunction.deployment.json` and setting the full url at release time. Then is just passing that file a another paramater file
- Deploy function app. Before we use to just run the ARM templates that will basically reset the function app. Internally they will use the zip to make the deployment.
- The managed identity use for deployment must have contributor roles to the storage account in order to upload the zip package.
- The managed identity of the azure function app must have at least reader roles to the storage account where the blob is updated. Each function app already have contributor roles to the storage account, so instead of using user assigned managed identities, I'm using the system assigned identity of the function app. 

With these we completely remove the need to use access keys in the storage accounts used for azure functions.
I also moved away from app registrations to user assigned managed identities for deployment.