### PR TITLE
Fix Component Governance alerts

### DIFF
--- a/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
+++ b/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
@@ -56,6 +56,7 @@
         <PackageReference Include="System.Security.Cryptography.X509Certificates" Version="4.3.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
         <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+        <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\Microsoft.WindowsPackageManager.Rest\Microsoft.WindowsPackageManager.Rest.csproj" />

--- a/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
+++ b/src/WinGet.RestSource.AppConfig/WinGet.RestSource.AppConfig.csproj
@@ -42,13 +42,12 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.22.0" />
         <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="4.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.12" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="7.2.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
         <PackageReference Include="Microsoft.FeatureManagement" Version="2.2.0" />
-        <PackageReference Include="Azure.Identity" Version="1.11.3" />
+        <PackageReference Include="Azure.Identity" Version="1.11.4" />
     </ItemGroup>
 
     <!-- Component Governance fix Item Group. -->

--- a/src/WinGet.RestSource.Functions/SourceFunctions.cs
+++ b/src/WinGet.RestSource.Functions/SourceFunctions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SourceFunctions.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -311,8 +311,6 @@ namespace Microsoft.WinGet.RestSource.Functions
                 customDimensions.Add("FunctionName", executionContext.FunctionName);
                 customDimensions.Add("OperationId", inputHelper.OperationId);
 
-                this.telemetryClient.TrackEvent("ExecutionStart", customDimensions);
-
                 durableContext.LogInfo($"{loggingContext}{orchestrationFunction} executed at: {durableContext.CurrentUtcDateTime}." +
                     $" Calling {activityFunction} activity function.");
 
@@ -326,10 +324,7 @@ namespace Microsoft.WinGet.RestSource.Functions
             catch (Exception e)
             {
                 durableContext.LogError($"{loggingContext}Error occurred in SourceOrchestratorHelperAsync {e}");
-
-                this.telemetryClient.TrackException(e, customDimensions);
                 customDimensions.Add("Exception", e.GetType().FullName);
-
                 Metrics.EmitMetric(errorMetric, customDimensions, logger);
             }
             finally
@@ -339,7 +334,6 @@ namespace Microsoft.WinGet.RestSource.Functions
                     durableContext.LogInfo($"{loggingContext}Task result: {sourceResultOutput}");
                 }
 
-                this.telemetryClient.TrackEvent("ExecutionCompleted", customDimensions);
                 customDimensions.Add("Result", sourceResultOutput.ToString());
             }
 

--- a/src/WinGet.RestSource.Functions/Startup.cs
+++ b/src/WinGet.RestSource.Functions/Startup.cs
@@ -25,6 +25,7 @@ namespace Microsoft.WinGet.RestSource.Functions
     using Microsoft.WinGet.RestSource.Interfaces;
     using Microsoft.WinGet.RestSource.Utils.Common;
     using Microsoft.WinGet.RestSource.Utils.Constants;
+    using YamlDotNet.Core.Tokens;
 
     /// <summary>
     /// Azure function startup class.
@@ -66,12 +67,14 @@ namespace Microsoft.WinGet.RestSource.Functions
             builder.Services.AddSingleton<TelemetryConfiguration>(sp =>
             {
                 var key = AzureFunctionEnvironment.AppInsightsInstrumentationKey;
+                var telemetryConfiguration = new TelemetryConfiguration();
+
                 if (!string.IsNullOrWhiteSpace(key))
                 {
-                    return new TelemetryConfiguration(key);
+                    telemetryConfiguration.ConnectionString = key;
                 }
 
-                return new TelemetryConfiguration();
+                return telemetryConfiguration;
             });
         }
     }

--- a/src/WinGet.RestSource.Functions/Startup.cs
+++ b/src/WinGet.RestSource.Functions/Startup.cs
@@ -71,7 +71,7 @@ namespace Microsoft.WinGet.RestSource.Functions
 
                 if (!string.IsNullOrWhiteSpace(key))
                 {
-                    telemetryConfiguration.ConnectionString = key;
+                    telemetryConfiguration.ConnectionString = $"InstrumentationKey={key}";
                 }
 
                 return telemetryConfiguration;

--- a/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
+++ b/src/WinGet.RestSource.Functions/WinGet.RestSource.Functions.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.CosmosDB" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.7.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.DurableTask" Version="2.13.5" />
   </ItemGroup>
 
   <!-- Component Governance fix Item Group. -->

--- a/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 // <copyright file="SourceFunctionsTests.cs" company="Microsoft Corporation">
 //     Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 // </copyright>
@@ -51,7 +51,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
             this.telemetryConfiguration = new TelemetryConfiguration
             {
                 TelemetryChannel = this.mockTelemetryChannel.Object,
-                InstrumentationKey = Guid.NewGuid().ToString(),
+                ConnectionString = Guid.NewGuid().ToString(),
             };
 
             this.mockHttpClientFactory.Setup(

--- a/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
             this.telemetryConfiguration = new TelemetryConfiguration
             {
                 TelemetryChannel = this.mockTelemetryChannel.Object,
-                ConnectionString = "key1=value1",
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
             };
 
             this.mockHttpClientFactory.Setup(

--- a/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
+++ b/src/WinGet.RestSource.UnitTest/Tests/AzFunctions/SourceFunctionsTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Winget.RestSource.UnitTest.Tests.AzFunctions
             this.telemetryConfiguration = new TelemetryConfiguration
             {
                 TelemetryChannel = this.mockTelemetryChannel.Object,
-                ConnectionString = Guid.NewGuid().ToString(),
+                ConnectionString = "key1=value1",
             };
 
             this.mockHttpClientFactory.Setup(

--- a/src/WinGet.RestSource/WinGet.RestSource.csproj
+++ b/src/WinGet.RestSource/WinGet.RestSource.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.22.0" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="6.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
   </ItemGroup>
 
   <!-- Component Governance fix Item Group. -->
@@ -56,6 +56,7 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/WinGet.RestSource/WinGet.RestSource.csproj
+++ b/src/WinGet.RestSource/WinGet.RestSource.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The following packages were updated:
- Microsoft.Extensions.Configuration.AzureAppConfiguration from 4.1.0 to 7.2.0
- Microsoft.Extensions.Configuration.Binder from 3.1.12 to 6.0.0
- Microsoft.Extensions.DependencyInjection from 3.1.12 to 6.0.1
- Azure.Identity from 1.11.3 to 1.11.4

The following packages were explicitly updated as the flagged version is a dependency of another pacakge:
- System.Data.SqlClient 4.8.6
- Azure.Security.KeyVault.Secrets 4.6.0

Other changes:
- The `TelemetryConfiguration` constructor with the instrumentation key is now obsolete. Instead one must set the connection string.
- There are more static analysis for Azure functions. In this case, we cannot use a member object in an orchestrator. Removed calls to `telemetryClient`. We are still going to get telemetry for activity functions.

