### PR TITLE
Use OneBranch for signing

### DIFF
--- a/pipelines/publish-powershell-module.yml
+++ b/pipelines/publish-powershell-module.yml
@@ -13,6 +13,9 @@ variables:
   sourceArtifactName: WinGet.RestSource-WinGet.PowerShell.Source
   downloadRoot: $(Pipeline.Workspace)\buildRelease\$(sourceArtifactName)
 
+  # Docker image which is used to build the project
+  WindowsContainerImage: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest'
+
 resources:
   pipelines:
   - pipeline: buildRelease
@@ -20,30 +23,31 @@ resources:
     trigger: none
 
   repositories:
-  - repository: 1ESPipelineTemplates
-    type: git
-    name: 1ESPipelineTemplates/1ESPipelineTemplates
-    ref: refs/tags/release
+    - repository: templates
+      type: git
+      name: OneBranch.Pipelines/GovernedTemplates
+      ref: refs/heads/main
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  template: v2/Microsoft.Official.yml@templates
   parameters:
-    pool:
-      name: Azure-Pipelines-1ESPT-ExDShared
-      image: windows-2022
-      os: windows
-    customBuildTags:
-      - ES365AIMigrationTooling
-    settings:
-      skipBuildTagsForGitHubPullRequests: true
+    platform:
+      name: 'windows_undocked'
+
+    git:
+      fetchTags: false
 
     stages:
       - stage: Prepare
         jobs:
         - job: Prepare_Sign
-          displayName: Prepare and sign $(moduleName)
-          steps:
+          displayName: Prepare and sign
+          pool:
+            type: windows
+          variables:
+            ob_outputDirectory: $(Build.ArtifactStagingDirectory)/$(moduleName)
 
+          steps:
           - task: NuGetToolInstaller@1
             displayName: 'Use NuGet 6.x'
             inputs:
@@ -75,86 +79,27 @@ extends:
               Get-Content -Path $psd1File -Raw
             displayName: 'PowerShell: Prepare Microsoft.WinGet.RestSource Module'
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+          - task: onebranch.pipeline.signing@1
             displayName: 'Sign 1st party module files'
             inputs:
-              ConnectedServiceName: AppInstallerESRPCodeSigning
-              AppRegistrationClientId: '32216f16-efc9-4013-9fae-c6a2c54a3fc0'
-              AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-              AuthAKVName: PeetDevOpsKeyVault
-              AuthCertName: ESRPAuth
-              AuthSignCertName: ESRPRequestSigning
-              FolderPath: '$(downloadRoot)'
-              Pattern: |
-                **/Microsoft.WinGet.RestSource.psd1
-                **/Microsoft.WinGet.RestSource.psm1
-                **/Library/*.ps1
-                **/Library/WinGet.RestSource.PowershellSupport/Microsoft.WinGet.PowershellSupport.dll
-                **/Library/WinGet.RestSource.PowershellSupport/Microsoft.WinGet.RestSource.Utils.dll
-              UseMinimatch: true
-              signConfigType: inlineSignParams
-              inlineOperation: |
-                [
-                  {
-                      "KeyCode" : "CP-230012",
-                      "OperationCode" : "SigntoolSign",
-                      "Parameters" : {
-                          "OpusName" : "Microsoft",
-                          "OpusInfo" : "http://www.microsoft.com",
-                          "FileDigest" : "/fd \"SHA256\"",
-                          "PageHash" : "/NPH",
-                          "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      },
-                      "ToolName" : "sign",
-                      "ToolVersion" : "1.0"
-                  },
-                  {
-                      "KeyCode" : "CP-230012",
-                      "OperationCode" : "SigntoolVerify",
-                      "Parameters" : {},
-                      "ToolName" : "sign",
-                      "ToolVersion" : "1.0"
-                  }
-                ]
+              command: 'sign'
+              signing_profile: 'external_distribution'
+              search_root: '$(downloadRoot)'
+              files_to_sign: |
+                Microsoft.WinGet.RestSource.psd1
+                Microsoft.WinGet.RestSource.psm1
+                Library/*.ps1
+                Library/WinGet.RestSource.PowershellSupport/Microsoft.WinGet.PowershellSupport.dll
+                Library/WinGet.RestSource.PowershellSupport/Microsoft.WinGet.RestSource.Utils.dll
 
-          - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@5
+          - task: onebranch.pipeline.signing@1
             displayName: 'Sign 3rd party module files'
             inputs:
-              ConnectedServiceName: AppInstallerESRPCodeSigning
-              AppRegistrationClientId: '32216f16-efc9-4013-9fae-c6a2c54a3fc0'
-              AppRegistrationTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-              AuthAKVName: PeetDevOpsKeyVault
-              AuthCertName: ESRPAuth
-              AuthSignCertName: ESRPRequestSigning
-              FolderPath: '$(downloadRoot)'
-              Pattern: |
-                **/Library/WinGet.RestSource.PowershellSupport/YamlDotNet.dll
-              UseMinimatch: true
-              signConfigType: inlineSignParams
-              inlineOperation: |
-                [
-                  {
-                      "KeyCode" : "CP-231522",
-                      "OperationCode" : "SigntoolSign",
-                      "Parameters" : {
-                          "OpusName" : "Microsoft",
-                          "OpusInfo" : "http://www.microsoft.com",
-                          "FileDigest" : "/fd \"SHA256\"",
-                          "Append" : "/as",
-                          "PageHash" : "/NPH",
-                          "TimeStamp" : "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      },
-                      "ToolName" : "sign",
-                      "ToolVersion" : "1.0"
-                  },
-                  {
-                      "KeyCode" : "CP-231522",
-                      "OperationCode" : "SigntoolVerify",
-                      "Parameters" : {},
-                      "ToolName" : "sign",
-                      "ToolVersion" : "1.0"
-                  }
-                ]
+              command: 'sign'
+              cp_code: '135020002' # CP-231522 - Microsoft 3rd Party Application Component (SHA2)
+              search_root: '$(downloadRoot)'
+              files_to_sign: |
+                Library/WinGet.RestSource.PowershellSupport/YamlDotNet.dll
 
           - task: CopyFiles@2
             displayName: Copy files to be published to staging directory
@@ -167,23 +112,34 @@ extends:
                 Library/**
                 Data/**
 
-          - task: 1ES.PublishPipelineArtifact@1
-            inputs:
-              targetPath: $(Build.ArtifactStagingDirectory)/$(moduleName)
-              artifactName: $(moduleName)
-              displayName: Publish Module Artifact
-
       - stage: Publish
         displayName: Manual Approval
-        trigger: manual
+        dependsOn: Prepare
         jobs:
-        - job: PublishToGallery
-          steps:
+        - job: Wait
+          displayName: Wait for manual approval
+          pool:
+            type: agentless
 
+          timeoutInMinutes: 1440 # job times out in 1 day
+
+          steps:
+            - task: ManualValidation@0
+              timeoutInMinutes: 1440 # task times out in 1 day
+
+        - job: PublishToGallery
+          dependsOn: Wait
+          pool:
+            type: windows
+          variables:
+            # Not used, but required by the pipeline to be defined
+            ob_outputDirectory: $(Build.ArtifactStagingDirectory)
+
+          steps:
           - task: DownloadPipelineArtifact@2
             inputs:
               buildType: current
-              artifactName: $(moduleName)
+              artifactName: drop_Prepare_Prepare_Sign
               targetPath: $(System.DefaultWorkingDirectory)/ModuleToPublish/$(moduleName)
               itemPattern: |
                 *.psm1


### PR DESCRIPTION
Change the release pipeline to use OneBranch instead of 1ES Pipeline Templates. This allows us to use their registration for ESRP instead of having our own.