### PR TITLE
Add workflow for automatic issue deduplication

### DIFF
--- a/.github/workflows/automatic-issue-deduplication.yml
+++ b/.github/workflows/automatic-issue-deduplication.yml
@@ -1,0 +1,19 @@
+name: Automatic New Issue Deduplication
+on:
+  issues:
+    types: [opened, reopened]
+permissions:
+  models: read
+  issues: write
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: true
+jobs:
+  deduplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Deduplicate Action
+        uses: pelikhan/action-genai-issue-dedup@v0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          label_as_duplicate: true


### PR DESCRIPTION
This adds a bot to automatically detect duplicate issues after an issue is opened or re-opened. It can only apply the "duplicate" label. It will not close the issue and it will leave a comment with the duplicate issue(s).